### PR TITLE
Adding string as unittest name

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -750,11 +750,13 @@ struct ASTBase
     extern (C++) final class UnitTestDeclaration : FuncDeclaration
     {
         char* codedoc;
+        char* name;
 
-        extern (D) this(const ref Loc loc, Loc endloc, StorageClass stc, char* codedoc)
+        extern (D) this(const ref Loc loc, Loc endloc, StorageClass stc, char* codedoc, char* name)
         {
             super(loc, endloc, Identifier.generateIdWithLoc("__unittest", loc), stc, null);
             this.codedoc = codedoc;
+            this.name = name;
         }
 
         override void accept(Visitor v)

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -890,6 +890,7 @@ class UnitTestDeclaration final : public FuncDeclaration
 {
 public:
     char *codedoc; /** For documented unittest. */
+    char *name; /** For naming unittest. */
 
     // toObjFile() these nested functions after this one
     FuncDeclarations deferredNested;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -4053,6 +4053,7 @@ class UnitTestDeclaration final : public FuncDeclaration
 {
 public:
     char* codedoc;
+    char* name;
     Array<FuncDeclaration* > deferredNested;
     UnitTestDeclaration* syntaxCopy(Dsymbol* s) override;
     AggregateDeclaration* isThis() override;

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -4430,20 +4430,22 @@ extern (C++) final class InvariantDeclaration : FuncDeclaration
 extern (C++) final class UnitTestDeclaration : FuncDeclaration
 {
     char* codedoc;      // for documented unittest
+    char* name;      // name of unittest
 
     // toObjFile() these nested functions after this one
     FuncDeclarations deferredNested;
 
-    extern (D) this(const ref Loc loc, const ref Loc endloc, StorageClass stc, char* codedoc)
+    extern (D) this(const ref Loc loc, const ref Loc endloc, StorageClass stc, char* codedoc, char* name)
     {
         super(loc, endloc, Identifier.generateIdWithLoc("__unittest", loc), stc, null);
         this.codedoc = codedoc;
+        this.name = name;
     }
 
     override UnitTestDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
-        auto utd = new UnitTestDeclaration(loc, endloc, storage_class, codedoc);
+        auto utd = new UnitTestDeclaration(loc, endloc, storage_class, codedoc, name);
         FuncDeclaration.syntaxCopy(utd);
         return utd;
     }

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -528,7 +528,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                     }
                     // Workaround 14894. Add an empty unittest declaration to keep
                     // the number of symbols in this scope independent of -unittest.
-                    s = new AST.UnitTestDeclaration(loc, token.loc, STC.undefined_, null);
+                    s = new AST.UnitTestDeclaration(loc, token.loc, STC.undefined_, null, null);
                 }
                 break;
 
@@ -2732,8 +2732,12 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
     {
         const loc = token.loc;
         StorageClass stc = getStorageClass!AST(pAttrs);
-
+        const(char)* unittestName;
         nextToken();
+        if (token.value == TOK.string_) {
+            unittestName = token.toChars;
+            nextToken();
+        }
 
         const(char)* begPtr = token.ptr + 1; // skip left curly brace
         const(char)* endPtr = null;
@@ -2760,7 +2764,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             }
         }
 
-        auto f = new AST.UnitTestDeclaration(loc, token.loc, stc, docline);
+        auto f = new AST.UnitTestDeclaration(loc, token.loc, stc, docline, cast(char*)unittestName);
         f.fbody = sbody;
         return f;
     }


### PR DESCRIPTION
First review round:
Hi I have added optional unittest naming as string.
```
void main () {
}

unittest "Should definitely be true" {
    assert (1 == 1);
}

unittest {
    assert (1 != 1);
}
```

I imagine we can use the name to run specific tests.
example in gtest you use a 
filter to state the test you wan't execute:
`--gtest_filter=-ABC.*:BCD.*`