### PR TITLE
Added __traits getUnitTestName

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -751,12 +751,14 @@ struct ASTBase
     {
         char* codedoc;
         char* name;
+        uint len;
 
-        extern (D) this(const ref Loc loc, Loc endloc, StorageClass stc, char* codedoc, char* name)
+        extern (D) this(const ref Loc loc, Loc endloc, StorageClass stc, char* codedoc, char* name, uint len)
         {
             super(loc, endloc, Identifier.generateIdWithLoc("__unittest", loc), stc, null);
             this.codedoc = codedoc;
             this.name = name;
+            this.len = len
         }
 
         override void accept(Visitor v)

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -8821,6 +8821,7 @@ struct Id final
     static Identifier* getFunctionVariadicStyle;
     static Identifier* getParameterStorageClasses;
     static Identifier* getLinkage;
+    static Identifier* getUnitTestName;
     static Identifier* getUnitTests;
     static Identifier* getVirtualIndex;
     static Identifier* getPointerBitmap;

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -4431,21 +4431,23 @@ extern (C++) final class UnitTestDeclaration : FuncDeclaration
 {
     char* codedoc;      // for documented unittest
     char* name;      // name of unittest
+    uint len;      // length of name
 
     // toObjFile() these nested functions after this one
     FuncDeclarations deferredNested;
 
-    extern (D) this(const ref Loc loc, const ref Loc endloc, StorageClass stc, char* codedoc, char* name)
+    extern (D) this(const ref Loc loc, const ref Loc endloc, StorageClass stc, char* codedoc, char* name, uint len)
     {
         super(loc, endloc, Identifier.generateIdWithLoc("__unittest", loc), stc, null);
         this.codedoc = codedoc;
         this.name = name;
+        this.len = len;
     }
 
     override UnitTestDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
-        auto utd = new UnitTestDeclaration(loc, endloc, storage_class, codedoc, name);
+        auto utd = new UnitTestDeclaration(loc, endloc, storage_class, codedoc, name, len);
         FuncDeclaration.syntaxCopy(utd);
         return utd;
     }

--- a/compiler/src/dmd/id.d
+++ b/compiler/src/dmd/id.d
@@ -499,6 +499,7 @@ immutable Msgtable[] msgtable =
     { "getFunctionVariadicStyle" },
     { "getParameterStorageClasses" },
     { "getLinkage" },
+    { "getUnitTestName" },
     { "getUnitTests" },
     { "getVirtualIndex" },
     { "getPointerBitmap" },

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -528,7 +528,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                     }
                     // Workaround 14894. Add an empty unittest declaration to keep
                     // the number of symbols in this scope independent of -unittest.
-                    s = new AST.UnitTestDeclaration(loc, token.loc, STC.undefined_, null, null);
+                    s = new AST.UnitTestDeclaration(loc, token.loc, STC.undefined_, null, null, 0);
                 }
                 break;
 
@@ -2733,9 +2733,11 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         const loc = token.loc;
         StorageClass stc = getStorageClass!AST(pAttrs);
         const(char)* unittestName;
+        uint unitTestNameLength;
         nextToken();
         if (token.value == TOK.string_) {
             unittestName = token.toChars;
+            unitTestNameLength = token.len;
             nextToken();
         }
 
@@ -2764,7 +2766,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             }
         }
 
-        auto f = new AST.UnitTestDeclaration(loc, token.loc, stc, docline, cast(char*)unittestName);
+        auto f = new AST.UnitTestDeclaration(loc, token.loc, stc, docline, cast(char*)unittestName, unitTestNameLength);
         f.fbody = sbody;
         return f;
     }

--- a/compiler/src/dmd/traits.d
+++ b/compiler/src/dmd/traits.d
@@ -1799,6 +1799,25 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                 return False();
         return True();
     }
+    if (e.ident == Id.getUnitTestName) 
+    {
+        auto o = (*e.args)[0];
+        auto s = getDsymbolWithoutExpCtx(o);
+        if (auto ud = s.isUnitTestDeclaration())
+        {
+            auto unitTest = cast(UnitTestDeclaration)s;
+            if (unitTest.len == 0) {
+                // Nameless unittest
+                auto se = new StringExp(e.loc, "");
+                return se.expressionSemantic(sc);
+            }
+            // Extract the name
+            char[] nameWithoutQuotes = unitTest.name[1..unitTest.len + 1];
+            auto se = new StringExp(e.loc, nameWithoutQuotes);
+            return se.expressionSemantic(sc);
+        }
+        error(e.loc, "argument `%s` to __traits(getUnitTestName) must be a UnitTest", o.toChars);
+    }
     if (e.ident == Id.getUnitTests)
     {
         if (dim != 1)
@@ -2252,7 +2271,7 @@ private void traitNotFound(TraitsExp e)
         initialized = true;     // lazy initialization
 
         // All possible traits
-        __gshared Identifier*[59] idents =
+        __gshared Identifier*[60] idents =
         [
             &Id.allMembers,
             &Id.child,
@@ -2273,6 +2292,7 @@ private void traitNotFound(TraitsExp e)
             &Id.getPointerBitmap,
             &Id.getProtection,
             &Id.getTargetInfo,
+            &Id.getUnitTestName,
             &Id.getUnitTests,
             &Id.getVirtualFunctions,
             &Id.getVirtualIndex,


### PR DESCRIPTION
Hi I have added a trait for getting the names of Unit Tests
So now it's possible to do this to extract the names from the unittests, if nameless then the name is empty ""
```
module foo;
unittest {
}

unittest "My named test" {
}

void main() {
    foreach(test; __traits(getUnitTests, foo)) {
        static assert(__traits(getUnitTestName, test) == "My named test");
    }
}
```