### PR TITLE
LDC should define D_OpenD too.

### DIFF
--- a/ldc/driver/main.cpp
+++ b/ldc/driver/main.cpp
@@ -953,6 +953,7 @@ void registerPredefinedVersions() {
   VersionCondition::addPredefinedGlobalIdent("LDC");
   VersionCondition::addPredefinedGlobalIdent("all");
   VersionCondition::addPredefinedGlobalIdent("D_Version2");
+  VersionCondition::addPredefinedGlobalIdent("D_OpenD");
 
 #if LDC_LLVM_SUPPORTED_TARGET_SPIRV || LDC_LLVM_SUPPORTED_TARGET_NVPTX
   if (dcomputeTargets.size() != 0) {


### PR DESCRIPTION
Toy example:
````
import std;

void main() {
	int i = 10;
	string abc = "hooray";
	float j = 1.5;

	version(D_OpenD)
		writeln(i"i=$(i) abc=$(abc) j=$(j)");
	else
		writeln("ur compiler sux");
}
````

Current output:
````
ur compiler sux
````

Output after PR:
````
i=10 abc=hooray j=1.5
````