### PR TITLE
Add opUnaryRight

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -8662,6 +8662,7 @@ struct Id final
     static Identifier* opDispatch;
     static Identifier* opDollar;
     static Identifier* opUnary;
+    static Identifier* opUnaryRight;
     static Identifier* opIndexUnary;
     static Identifier* opSliceUnary;
     static Identifier* opBinary;

--- a/compiler/src/dmd/id.d
+++ b/compiler/src/dmd/id.d
@@ -278,6 +278,7 @@ immutable Msgtable[] msgtable =
     { "opDispatch" },
     { "opDollar" },
     { "opUnary" },
+    { "opUnaryRight" },
     { "opIndexUnary" },
     { "opSliceUnary" },
     { "opBinary" },

--- a/compiler/src/dmd/opover.d
+++ b/compiler/src/dmd/opover.d
@@ -633,6 +633,21 @@ Expression op_overload(Expression e, Scope* sc, EXP* pop = null)
             Objects* tiargs = null;
             if (e.op == EXP.plusPlus || e.op == EXP.minusMinus)
             {
+                // if opUnaryRight is defined it will be used for e++ and e-- expressions. If opUnaryRight
+                // is not defined it is lowered to (auto t = e, e.opUnary!"++", t) and similar.
+                if (ad1)
+                {
+                    s = search_function(ad1, Id.opUnaryRight);
+                    if (s)
+                    {
+                        tiargs = opToArg(sc, e.op);
+                        Expression result = new DotTemplateInstanceExp(e.loc, e.e1, s.ident, tiargs);
+                        result = new CallExp(e.loc, result);
+                        result = result.expressionSemantic(sc);
+                        return result;
+                    }
+                }
+
                 // Bug4099 fix
                 if (ad1 && search_function(ad1, Id.opUnary))
                     return null;

--- a/compiler/test/runnable/opover2.d
+++ b/compiler/test/runnable/opover2.d
@@ -1987,6 +1987,65 @@ void test14625()
 }
 
 /**************************************/
+// Test opUnaryRight
+
+void Test21()
+{
+    struct S
+    {
+        int val;
+
+        int opUnary(string op)()
+        {
+            if (op == "++")
+            {
+                return ++val;
+            }
+            else if(op == "--")
+            {
+                return --val;
+            }
+
+            assert(false);
+        }
+
+        int opUnaryRight(string op)()
+        {
+            if (op == "++")
+            {
+                int tmp = val;
+                val += 10;
+                return tmp;
+            }
+            else if(op == "--")
+            {
+                int tmp = val;
+                val -= 10;
+                return tmp;
+            }
+
+            assert(false);
+        }
+    }
+
+    S s;
+    int j;
+    j = ++s;
+    assert(s.val == 1);
+    assert(j == 1);
+    j = --s;
+    assert(s.val == 0);
+    assert(j == 0);
+    j = s++;
+    assert(s.val == 10);
+    assert(j == 0);
+    j = s--;
+    assert(s.val == 0);
+    assert(j == 10);
+}
+
+
+/**************************************/
 
 int main()
 {
@@ -2033,6 +2092,7 @@ int main()
     test20d();
     test14624();
     test14625();
+    Test21();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
Added the ability to overload the post increment/decrement using opUnaryRight.

This PR was originally inspired by this issue.

https://issues.dlang.org/show_bug.cgi?id=20123

PR:
https://github.com/dlang/dmd/pull/12301

The intention was to be able to disable the post inc/dec in order to avoid any problems regarding atomic operation.

One post in the PR was 
> as in the only thing you are allowed to do with opUnaryRight is to @disable it.

>For the moment. Give it some days and people in the forums will demand it to be usable properly.


Currently the post inc/dec is implemented by lowering only without any possbility to override it, https://dlang.org/spec/operatoroverloading.html.

```e--``` becomes ```(auto t = e, e.opUnary!"--", t)```
```e++``` becomes ```(auto t = e, e.opUnary!"++", t)```

which is restrictive. Why not go with the full functionality in order to be able to customize the post inc/dec. This for example enables C++ like atomics. This change will also help porting from C++ in general.

Ex.
```d
struct Atomic(T)
{
    T val;

    T opUnary(string op)()
    {
        if (op == "++") 
        {
            return val.atomicFetchAdd(1) + 1;
        }
        else if(op == "--")
        {
            return val.atomicFetchSub(1) - 1;
        }

        assert(false);
    }

    T opUnaryRight(string op)()
    {
        if (op == "++") 
        {
            return val.atomicFetchAdd(1);
        }
        else if(op == "--")
        {
            return val.atomicFetchSub(1);
        }

        assert(false);
    }
}
```

According to: https://en.cppreference.com/w/cpp/atomic/atomic/operator_arith

Another problem without overloading post inc/dec is that the lowering demands that the return type must be of the same type as the operator type.

```d
    struct S { ... }
    S v;

    S r1 = v++; // works
    int r2 = v++; // will never work
```

This change remain compatible with existing code. The trigger is that as soon the programmer adds opUnaryRight to the type, the compiler will instead try to insert the call instead of lowering.