### PR TITLE
Move compiler dependent atomics to core/internal/atomic.d

### DIFF
--- a/druntime/src/core/internal/atomic.d
+++ b/druntime/src/core/internal/atomic.d
@@ -34,30 +34,35 @@ version (LDC)
     T atomicFetchAdd(MemoryOrder order = MemoryOrder.seq, T)(T* dest, T value) pure nothrow @nogc @trusted
     {
         alias A = _AtomicType!T;
+        static assert(__traits(isIntegral, T) && T.sizeof <= AtomicRmwSizeLimit);
         return llvm_atomic_rmw_add!A(cast(shared A*) dest, value, _ordering!(order));
     }
 
     T atomicFetchSub(MemoryOrder order = MemoryOrder.seq, T)(T* dest, T value) pure nothrow @nogc @trusted
     {
         alias A = _AtomicType!T;
+        static assert(__traits(isIntegral, T) && T.sizeof <= AtomicRmwSizeLimit);
         return llvm_atomic_rmw_sub!A(cast(shared A*) dest, value, _ordering!(order));
     }
 
     T atomicFetchAnd(MemoryOrder order = MemoryOrder.seq, T)(T* dest, T value) pure nothrow @nogc @trusted
     {
         alias A = _AtomicType!T;
+        static assert(__traits(isIntegral, T) && T.sizeof <= AtomicRmwSizeLimit);
         return llvm_atomic_rmw_and!A(cast(shared A*) dest, value, _ordering!(order));
     }
 
     T atomicFetchOr(MemoryOrder order = MemoryOrder.seq, T)(T* dest, T value) pure nothrow @nogc @trusted
     {
         alias A = _AtomicType!T;
+        static assert(__traits(isIntegral, T) && T.sizeof <= AtomicRmwSizeLimit);
         return llvm_atomic_rmw_or!A(cast(shared A*) dest, value, _ordering!(order));
     }
 
     T atomicFetchXor(MemoryOrder order = MemoryOrder.seq, T)(T* dest, T value) pure nothrow @nogc @trusted
     {
         alias A = _AtomicType!T;
+        static assert(__traits(isIntegral, T) && T.sizeof <= AtomicRmwSizeLimit);
         return llvm_atomic_rmw_xor!A(cast(shared A*) dest, value, _ordering!(order));
     }
 
@@ -478,7 +483,7 @@ version (DigitalMars)
     T atomicFetchAnd(MemoryOrder order = MemoryOrder.seq, T)(T* dest, T value) pure nothrow @nogc @trusted
     if (is(T : ulong))
     {
-        T set, get = atomicLoad!(order)(dest);
+        T set, get = atomicLoad!(MemoryOrder.raw)(dest);
 
         do
         {
@@ -491,7 +496,7 @@ version (DigitalMars)
     T atomicFetchOr(MemoryOrder order = MemoryOrder.seq, T)(T* dest, T value) pure nothrow @nogc @trusted
     if (is(T : ulong))
     {
-        T set, get = atomicLoad!(order)(dest);
+        T set, get = atomicLoad!(MemoryOrder.raw)(dest);
 
         do
         {
@@ -504,7 +509,7 @@ version (DigitalMars)
     T atomicFetchXor(MemoryOrder order = MemoryOrder.seq, T)(T* dest, T value) pure nothrow @nogc @trusted
     if (is(T : ulong))
     {
-        T set, get = atomicLoad!(order)(dest);
+        T set, get = atomicLoad!(MemoryOrder.raw)(dest);
 
         do
         {

--- a/druntime/src/core/stdc/stdatomic.d
+++ b/druntime/src/core/stdc/stdatomic.d
@@ -866,17 +866,7 @@ pragma(inline, true)
 A atomic_fetch_or_impl(A, M)(shared(A)* obj, M arg) @trusted
 {
     assert(obj !is null);
-
-    // copied from atomicOp
-
-    A set, get = atomicLoad(cast(A*)obj);
-
-    do
-    {
-        set = get | arg;
-    } while (!atomicCompareExchangeWeak!(memory_order.memory_order_seq_cst, memory_order.memory_order_seq_cst)(cast(A*)obj, &get, cast(A)set));
-
-    return get;
+    return atomicFetchOr(cast(A*)obj, arg);
 }
 
 ///
@@ -893,52 +883,19 @@ A atomic_fetch_or_explicit_impl(A, M)(shared(A)* obj, M arg, memory_order order)
 {
     assert(obj !is null);
 
-    A set, get;
-
     final switch(order)
     {
         case memory_order.memory_order_relaxed:
-            get = atomicLoad!(memory_order.memory_order_relaxed)(cast(A*)obj);
-            do
-            {
-                set = get | arg;
-            } while (!atomicCompareExchangeWeak!(memory_order.memory_order_relaxed, memory_order.memory_order_relaxed)(cast(A*)obj, &get, cast(A)set));
-            break;
-
+            return atomicFetchOr!(memory_order.memory_order_relaxed)(cast(A*)obj, arg);
         case memory_order.memory_order_acquire:
-            get = atomicLoad!(memory_order.memory_order_acquire)(cast(A*)obj);
-            do
-            {
-                set = get | arg;
-            } while (!atomicCompareExchangeWeak!(memory_order.memory_order_acquire, memory_order.memory_order_acquire)(cast(A*)obj, &get, cast(A)set));
-            break;
-
+            return atomicFetchOr!(memory_order.memory_order_acquire)(cast(A*)obj, arg);
         case memory_order.memory_order_release:
-            get = atomicLoad!(memory_order.memory_order_relaxed)(cast(A*)obj);
-            do
-            {
-                set = get | arg;
-            } while (!atomicCompareExchangeWeak!(memory_order.memory_order_release, memory_order.memory_order_release)(cast(A*)obj, &get, cast(A)set));
-            break;
-
+            return atomicFetchOr!(memory_order.memory_order_release)(cast(A*)obj, arg);
         case memory_order.memory_order_acq_rel:
-            get = atomicLoad!(memory_order.memory_order_acq_rel)(cast(A*)obj);
-            do
-            {
-                set = get | arg;
-            } while (!atomicCompareExchangeWeak!(memory_order.memory_order_acq_rel, memory_order.memory_order_acq_rel)(cast(A*)obj, &get, cast(A)set));
-            break;
-
+            return atomicFetchOr!(memory_order.memory_order_acq_rel)(cast(A*)obj, arg);
         case memory_order.memory_order_seq_cst:
-            get = atomicLoad!(memory_order.memory_order_relaxed)(cast(A*)obj);
-            do
-            {
-                set = get | arg;
-            } while (!atomicCompareExchangeWeak!(memory_order.memory_order_seq_cst, memory_order.memory_order_seq_cst)(cast(A*)obj, &get, cast(A)set));
-            break;
+            return atomicFetchOr!(memory_order.memory_order_seq_cst)(cast(A*)obj, arg);
     }
-
-    return get;
 }
 
 ///
@@ -954,17 +911,7 @@ pragma(inline, true)
 A atomic_fetch_xor_impl(A, M)(shared(A)* obj, M arg) @trusted
 {
     assert(obj !is null);
-
-    // copied from atomicOp
-
-    A set, get = atomicLoad(cast(A*)obj);
-
-    do
-    {
-        set = get ^ arg;
-    } while (!atomicCompareExchangeWeak!(memory_order.memory_order_seq_cst, memory_order.memory_order_seq_cst)(cast(A*)obj, &get, cast(A)set));
-
-    return get;
+    return atomicFetchXor(cast(A*)obj, arg);
 }
 
 ///
@@ -986,47 +933,16 @@ A atomic_fetch_xor_explicit_impl(A, M)(shared(A)* obj, M arg, memory_order order
     final switch(order)
     {
         case memory_order.memory_order_relaxed:
-            get = atomicLoad!(memory_order.memory_order_relaxed)(cast(A*)obj);
-            do
-            {
-                set = get ^ arg;
-            } while (!atomicCompareExchangeWeak!(memory_order.memory_order_relaxed, memory_order.memory_order_relaxed)(cast(A*)obj, &get, cast(A)set));
-            break;
-
+            return atomicFetchXor!(memory_order.memory_order_relaxed)(cast(A*)obj, arg);
         case memory_order.memory_order_acquire:
-            get = atomicLoad!(memory_order.memory_order_acquire)(cast(A*)obj);
-            do
-            {
-                set = get ^ arg;
-            } while (!atomicCompareExchangeWeak!(memory_order.memory_order_acquire, memory_order.memory_order_acquire)(cast(A*)obj, &get, cast(A)set));
-            break;
-
+            return atomicFetchXor!(memory_order.memory_order_acquire)(cast(A*)obj, arg);
         case memory_order.memory_order_release:
-            get = atomicLoad!(memory_order.memory_order_relaxed)(cast(A*)obj);
-            do
-            {
-                set = get ^ arg;
-            } while (!atomicCompareExchangeWeak!(memory_order.memory_order_release, memory_order.memory_order_release)(cast(A*)obj, &get, cast(A)set));
-            break;
-
+            return atomicFetchXor!(memory_order.memory_order_release)(cast(A*)obj, arg);
         case memory_order.memory_order_acq_rel:
-            get = atomicLoad!(memory_order.memory_order_acq_rel)(cast(A*)obj);
-            do
-            {
-                set = get ^ arg;
-            } while (!atomicCompareExchangeWeak!(memory_order.memory_order_acq_rel, memory_order.memory_order_acq_rel)(cast(A*)obj, &get, cast(A)set));
-            break;
-
+            return atomicFetchXor!(memory_order.memory_order_acq_rel)(cast(A*)obj, arg);
         case memory_order.memory_order_seq_cst:
-            get = atomicLoad!(memory_order.memory_order_relaxed)(cast(A*)obj);
-            do
-            {
-                set = get ^ arg;
-            } while (!atomicCompareExchangeWeak!(memory_order.memory_order_seq_cst, memory_order.memory_order_seq_cst)(cast(A*)obj, &get, cast(A)set));
-            break;
+            return atomicFetchXor!(memory_order.memory_order_seq_cst)(cast(A*)obj, arg);
     }
-
-    return get;
 }
 
 ///
@@ -1042,17 +958,7 @@ pragma(inline, true)
 A atomic_fetch_and_impl(A, M)(shared(A)* obj, M arg) @trusted
 {
     assert(obj !is null);
-
-    // copied from atomicOp
-
-    A set, get = atomicLoad(cast(A*)obj);
-
-    do
-    {
-        set = get & arg;
-    } while (!atomicCompareExchangeWeak!(memory_order.memory_order_seq_cst, memory_order.memory_order_seq_cst)(cast(A*)obj, &get, cast(A)set));
-
-    return get;
+    return atomicFetchAnd(cast(A*)obj, arg);
 }
 
 ///
@@ -1074,47 +980,16 @@ A atomic_fetch_and_explicit_impl(A, M)(shared(A)* obj, M arg, memory_order order
     final switch(order)
     {
         case memory_order.memory_order_relaxed:
-            get = atomicLoad!(memory_order.memory_order_relaxed)(cast(A*)obj);
-            do
-            {
-                set = get & arg;
-            } while (!atomicCompareExchangeWeak!(memory_order.memory_order_relaxed, memory_order.memory_order_relaxed)(cast(A*)obj, &get, cast(A)set));
-            break;
-
+            return atomicFetchAnd!(memory_order.memory_order_relaxed)(cast(A*)obj, arg);
         case memory_order.memory_order_acquire:
-            get = atomicLoad!(memory_order.memory_order_acquire)(cast(A*)obj);
-            do
-            {
-                set = get & arg;
-            } while (!atomicCompareExchangeWeak!(memory_order.memory_order_acquire, memory_order.memory_order_acquire)(cast(A*)obj, &get, cast(A)set));
-            break;
-
+            return atomicFetchAnd!(memory_order.memory_order_acquire)(cast(A*)obj, arg);
         case memory_order.memory_order_release:
-            get = atomicLoad!(memory_order.memory_order_relaxed)(cast(A*)obj);
-            do
-            {
-                set = get & arg;
-            } while (!atomicCompareExchangeWeak!(memory_order.memory_order_release, memory_order.memory_order_release)(cast(A*)obj, &get, cast(A)set));
-            break;
-
+            return atomicFetchAnd!(memory_order.memory_order_release)(cast(A*)obj, arg);
         case memory_order.memory_order_acq_rel:
-            get = atomicLoad!(memory_order.memory_order_acq_rel)(cast(A*)obj);
-            do
-            {
-                set = get & arg;
-            } while (!atomicCompareExchangeWeak!(memory_order.memory_order_acq_rel, memory_order.memory_order_acq_rel)(cast(A*)obj, &get, cast(A)set));
-            break;
-
+            return atomicFetchAnd!(memory_order.memory_order_acq_rel)(cast(A*)obj, arg);
         case memory_order.memory_order_seq_cst:
-            get = atomicLoad!(memory_order.memory_order_relaxed)(cast(A*)obj);
-            do
-            {
-                set = get & arg;
-            } while (!atomicCompareExchangeWeak!(memory_order.memory_order_seq_cst, memory_order.memory_order_seq_cst)(cast(A*)obj, &get, cast(A)set));
-            break;
+            return atomicFetchAnd!(memory_order.memory_order_seq_cst)(cast(A*)obj, arg);
     }
-
-    return get;
 }
 
 ///


### PR DESCRIPTION
Moved the architecture and compiler dependent atomic implementations to to core/internal/atomic.d.
core.atomic and stdc.stdatomic now uses the internal atomic implemenation instead in order to use compiler intrinsics.

Especially stdatomic now uses more intrinsics when using LDC in order to get better code generation.