### PR TITLE
Add Mutex OS API

### DIFF
--- a/druntime/mak/COPY
+++ b/druntime/mak/COPY
@@ -163,6 +163,8 @@ COPY=\
 	\
 	$(IMPDIR)\core\sys\darwin\netinet\in_.d \
 	\
+	$(IMPDIR)\core\sys\darwin\sync\osmutex.d \
+	\
 	$(IMPDIR)\core\sys\darwin\sys\cdefs.d \
 	$(IMPDIR)\core\sys\darwin\sys\event.d \
 	$(IMPDIR)\core\sys\darwin\sys\mman.d \
@@ -182,6 +184,8 @@ COPY=\
 	$(IMPDIR)\core\sys\freebsd\net\if_dl.d \
 	\
 	$(IMPDIR)\core\sys\freebsd\netinet\in_.d \
+	\
+	$(IMPDIR)\core\sys\freebsd\sync\osmutex.d \
 	\
 	$(IMPDIR)\core\sys\freebsd\sys\_bitset.d \
 	$(IMPDIR)\core\sys\freebsd\sys\_cpuset.d \
@@ -208,6 +212,8 @@ COPY=\
 	$(IMPDIR)\core\sys\dragonflybsd\stdlib.d \
 	$(IMPDIR)\core\sys\dragonflybsd\string.d \
 	$(IMPDIR)\core\sys\dragonflybsd\time.d \
+	\
+	$(IMPDIR)\core\sys\dragonflybsd\sync\osmutex.d \
 	\
 	$(IMPDIR)\core\sys\dragonflybsd\sys\_bitset.d \
 	$(IMPDIR)\core\sys\dragonflybsd\sys\_cpuset.d \
@@ -252,6 +258,8 @@ COPY=\
 	$(IMPDIR)\core\sys\linux\netinet\in_.d \
 	$(IMPDIR)\core\sys\linux\netinet\tcp.d \
 	\
+	$(IMPDIR)\core\sys\linux\sync\osmutex.d \
+	\
 	$(IMPDIR)\core\sys\linux\sys\auxv.d \
 	$(IMPDIR)\core\sys\linux\sys\eventfd.d \
 	$(IMPDIR)\core\sys\linux\sys\file.d \
@@ -270,6 +278,8 @@ COPY=\
 	$(IMPDIR)\core\sys\netbsd\stdlib.d \
 	$(IMPDIR)\core\sys\netbsd\string.d \
 	$(IMPDIR)\core\sys\netbsd\time.d \
+	\
+	$(IMPDIR)\core\sys\netbsd\sync\osmutex.d \
 	\
 	$(IMPDIR)\core\sys\netbsd\sys\elf.d \
 	$(IMPDIR)\core\sys\netbsd\sys\elf32.d \
@@ -290,6 +300,8 @@ COPY=\
 	$(IMPDIR)\core\sys\openbsd\string.d \
 	$(IMPDIR)\core\sys\openbsd\time.d \
 	$(IMPDIR)\core\sys\openbsd\unistd.d \
+	\
+	$(IMPDIR)\core\sys\openbsd\sync\osmutex.d \
 	\
 	$(IMPDIR)\core\sys\openbsd\sys\cdefs.d \
 	$(IMPDIR)\core\sys\openbsd\sys\elf.d \
@@ -339,6 +351,8 @@ COPY=\
 	\
 	$(IMPDIR)\core\sys\posix\stdc\time.d \
 	\
+	$(IMPDIR)\core\sys\posix\sync\osmutex.d \
+	\
 	$(IMPDIR)\core\sys\posix\sys\filio.d \
 	$(IMPDIR)\core\sys\posix\sys\ioccom.d \
 	$(IMPDIR)\core\sys\posix\sys\ioctl.d \
@@ -367,6 +381,8 @@ COPY=\
 	$(IMPDIR)\core\sys\solaris\link.d \
 	$(IMPDIR)\core\sys\solaris\stdlib.d \
 	$(IMPDIR)\core\sys\solaris\time.d \
+	\
+	$(IMPDIR)\core\sys\solaris\sync\osmutex.d \
 	\
 	$(IMPDIR)\core\sys\solaris\sys\elf.d \
 	$(IMPDIR)\core\sys\solaris\sys\elf_386.d \
@@ -547,6 +563,8 @@ COPY=\
 	$(IMPDIR)\core\sys\windows\winver.d \
 	$(IMPDIR)\core\sys\windows\wtsapi32.d \
 	$(IMPDIR)\core\sys\windows\wtypes.d \
+	\
+	$(IMPDIR)\core\sys\windows\sync\osmutex.d \
 	\
 	$(IMPDIR)\core\thread\context.d \
 	$(IMPDIR)\core\thread\fiber.d \

--- a/druntime/mak/SRCS
+++ b/druntime/mak/SRCS
@@ -161,6 +161,8 @@ SRCS=\
 	\
 	src\core\sys\darwin\netinet\in_.d \
 	\
+	src\core\sys\darwin\sync\osmutex.d \
+	\
 	src\core\sys\darwin\sys\cdefs.d \
 	src\core\sys\darwin\sys\event.d \
 	src\core\sys\darwin\sys\mman.d \
@@ -179,6 +181,8 @@ SRCS=\
 	src\core\sys\freebsd\net\if_dl.d \
 	\
 	src\core\sys\freebsd\netinet\in_.d \
+	\
+	src\core\sys\freebsd\sync\osmutex.d \
 	\
 	src\core\sys\freebsd\sys\_bitset.d \
 	src\core\sys\freebsd\sys\_cpuset.d \
@@ -203,6 +207,8 @@ SRCS=\
 	src\core\sys\dragonflybsd\stdlib.d \
 	src\core\sys\dragonflybsd\string.d \
 	src\core\sys\dragonflybsd\time.d \
+	\
+	src\core\sys\dragonflybsd\sync\osmutex.d \
 	\
 	src\core\sys\dragonflybsd\sys\_bitset.d \
 	src\core\sys\dragonflybsd\sys\_cpuset.d \
@@ -247,6 +253,8 @@ SRCS=\
 	src\core\sys\linux\netinet\in_.d \
 	src\core\sys\linux\netinet\tcp.d \
 	\
+	src\core\sys\linux\sync\osmutex.d \
+	\
 	src\core\sys\linux\sys\auxv.d \
 	src\core\sys\linux\sys\eventfd.d \
 	src\core\sys\linux\sys\file.d \
@@ -265,6 +273,8 @@ SRCS=\
 	src\core\sys\netbsd\stdlib.d \
 	src\core\sys\netbsd\string.d \
 	src\core\sys\netbsd\time.d \
+	\
+	src\core\sys\netbsd\sync\osmutex.d \
 	\
 	src\core\sys\netbsd\sys\elf.d \
 	src\core\sys\netbsd\sys\elf32.d \
@@ -285,6 +295,8 @@ SRCS=\
 	src\core\sys\openbsd\string.d \
 	src\core\sys\openbsd\time.d \
 	src\core\sys\openbsd\unistd.d \
+	\
+	src\core\sys\openbsd\sync\osmutex.d \
 	\
 	src\core\sys\openbsd\sys\cdefs.d \
 	src\core\sys\openbsd\sys\elf.d \
@@ -334,6 +346,8 @@ SRCS=\
 	\
 	src\core\sys\posix\stdc\time.d \
 	\
+	src\core\sys\posix\sync\osmutex.d \
+	\
 	src\core\sys\posix\sys\filio.d \
 	src\core\sys\posix\sys\ioccom.d \
 	src\core\sys\posix\sys\ioctl.d \
@@ -362,6 +376,9 @@ SRCS=\
 	src\core\sys\solaris\link.d \
 	src\core\sys\solaris\stdlib.d \
 	src\core\sys\solaris\time.d \
+	\
+	src\core\sys\solaris\sync\osmutex.d \
+	\
 	src\core\sys\solaris\sys\elf.d \
 	src\core\sys\solaris\sys\elf_386.d \
 	src\core\sys\solaris\sys\elf_amd64.d \
@@ -541,6 +558,8 @@ SRCS=\
 	src\core\sys\windows\winver.d \
 	src\core\sys\windows\wtsapi32.d \
 	src\core\sys\windows\wtypes.d \
+	\
+	src\core\sys\windows\sync\osmutex.d \
 	\
 	src\core\thread\fiber.d \
 	src\core\thread\types.d \

--- a/druntime/src/core/sys/darwin/sync/osmutex.d
+++ b/druntime/src/core/sys/darwin/sync/osmutex.d
@@ -1,0 +1,5 @@
+module core.sys.darwin.sync.osmutex;
+
+version (Darwin):
+
+public import core.sys.posix.sync.osmutex;

--- a/druntime/src/core/sys/dragonflybsd/sync/osmutex.d
+++ b/druntime/src/core/sys/dragonflybsd/sync/osmutex.d
@@ -1,0 +1,5 @@
+module core.sys.dragonflybsd.sync.osmutex;
+
+version (DragonFlyBSD):
+
+public import core.sys.posix.sync.osmutex;

--- a/druntime/src/core/sys/freebsd/sync/osmutex.d
+++ b/druntime/src/core/sys/freebsd/sync/osmutex.d
@@ -1,0 +1,5 @@
+module core.sys.freebsd.sync.osmutex;
+
+version (FreeBSD):
+
+public import core.sys.posix.sync.osmutex;

--- a/druntime/src/core/sys/linux/sync/osmutex.d
+++ b/druntime/src/core/sys/linux/sync/osmutex.d
@@ -1,0 +1,5 @@
+module core.sys.linux.sync.osmutex;
+
+version (linux):
+
+public import core.sys.posix.sync.osmutex;

--- a/druntime/src/core/sys/netbsd/sync/osmutex.d
+++ b/druntime/src/core/sys/netbsd/sync/osmutex.d
@@ -1,0 +1,5 @@
+module core.sys.netbsd.sync.osmutex;
+
+version (NetBSD):
+
+public import core.sys.posix.sync.osmutex;

--- a/druntime/src/core/sys/openbsd/sync/osmutex.d
+++ b/druntime/src/core/sys/openbsd/sync/osmutex.d
@@ -1,0 +1,5 @@
+module core.sys.openbsd.sync.osmutex;
+
+version (OpenBSD):
+
+public import core.sys.posix.sync.osmutex;

--- a/druntime/src/core/sys/posix/sync/osmutex.d
+++ b/druntime/src/core/sys/posix/sync/osmutex.d
@@ -1,0 +1,66 @@
+module core.sys.posix.sync.osmutex;
+
+version (Posix):
+
+import core.sync.exception;
+import core.sys.posix.pthread;
+
+struct OsMutex
+{
+    pthread_mutex_t     m_hndl;
+
+    void initialize() nothrow @trusted @nogc
+    {
+        import core.internal.abort : abort;
+        pthread_mutexattr_t attr = void;
+
+        !pthread_mutexattr_init(&attr) ||
+            abort("Error: pthread_mutexattr_init failed.");
+
+        scope (exit) !pthread_mutexattr_destroy(&attr) ||
+            abort("Error: pthread_mutexattr_destroy failed.");
+
+        !pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE) ||
+            abort("Error: pthread_mutexattr_settype failed.");
+
+        !pthread_mutex_init(cast(pthread_mutex_t*) &m_hndl, &attr) ||
+            abort("Error: pthread_mutex_init failed.");
+    }
+
+    void destroy() nothrow @trusted @nogc
+    {
+        import core.internal.abort : abort;
+            !pthread_mutex_destroy(&m_hndl) ||
+                abort("Error: pthread_mutex_destroy failed.");
+    }
+
+    void lockNoThrow() nothrow @trusted @nogc
+    {
+        if (pthread_mutex_lock(&m_hndl) == 0)
+            return;
+
+        SyncError syncErr = cast(SyncError) __traits(initSymbol, SyncError).ptr;
+        syncErr.msg = "Unable to lock mutex.";
+        throw syncErr;
+    }
+
+    void unlockNoThrow() nothrow @trusted @nogc
+    {
+         if (pthread_mutex_unlock(&m_hndl) == 0)
+            return;
+
+        SyncError syncErr = cast(SyncError) __traits(initSymbol, SyncError).ptr;
+        syncErr.msg = "Unable to unlock mutex.";
+        throw syncErr;
+    }
+
+    bool tryLockNoThrow() nothrow @trusted @nogc
+    {
+        return pthread_mutex_trylock(&m_hndl) == 0;
+    }
+
+    pthread_mutex_t* handleAddr() @nogc
+    {
+        return &m_hndl;
+    }
+}

--- a/druntime/src/core/sys/solaris/sync/osmutex.d
+++ b/druntime/src/core/sys/solaris/sync/osmutex.d
@@ -1,0 +1,5 @@
+module core.sys.solaris.sync.osmutex;
+
+version (Solaris):
+
+public import core.sys.posix.sync.osmutex;

--- a/druntime/src/core/sys/windows/sync/osmutex.d
+++ b/druntime/src/core/sys/windows/sync/osmutex.d
@@ -1,0 +1,37 @@
+module core.sys.windows.sync.osmutex;
+
+version (Windows):
+
+import core.sys.windows.winbase /+: CRITICAL_SECTION, DeleteCriticalSection,
+        EnterCriticalSection, InitializeCriticalSection, LeaveCriticalSection,
+        TryEnterCriticalSection+/;
+
+struct OsMutex
+{
+    CRITICAL_SECTION    m_hndl;
+
+    void initialize() nothrow @trusted @nogc
+    {
+        InitializeCriticalSection(cast(CRITICAL_SECTION*) &m_hndl);
+    }
+
+    void destroy() nothrow @trusted @nogc
+    {
+        DeleteCriticalSection(&m_hndl);
+    }
+
+    void lockNoThrow() nothrow @trusted @nogc
+    {
+        EnterCriticalSection(&m_hndl);
+    }
+
+    void unlockNoThrow() nothrow @trusted @nogc
+    {
+        LeaveCriticalSection(&m_hndl);
+    }
+
+    bool tryLockNoThrow() nothrow @trusted @nogc
+    {
+        return TryEnterCriticalSection(&m_hndl) != 0;
+    }
+}


### PR DESCRIPTION
This is an initial show case for creating an OS API for druntime. I've opted for creating a struct with associated methods with optional included OS data. Using explicit calls was chosen because order might be important and also so that it can be interleaved with druntime generic code. This also includes explicit initialization and deinitialization because order might be important here as well, even if it might not be that in this example.

You might notice a large awful version switch case in mutex.d and it is intentional. The plan is that the imported OS specific file shall in the future be automatically imported based on configuration. Basically an enum string would do it here. The file can be imported by a mixin.

```d
mixin("import core.sys." ~ config.osSysDir ~ ".sync.osmutex");
```

In the future when we have sorted out the OS configuration method this can be changed.

Another thing you notice is that each OS is responsible for the implementation and should not go to the POSIX implementation directly. Mutex is a very simple primitive that happens to be the same for every POSIX like OS but that might not always be the case. Then it is up to the OS implementation to augment the POSIX implementation if necessary. Also this is order for the future mixin import mentioned above to work properly.

In every OS implementation you also see in the beginning of the file something like:

```d
version (Windows):
```

This is because the makefile seems to visit all the files regardless of the OS target. This is totally unnecessary and hopefully the opend executable can be more selective and only compile files that are intended for the OS target. When this is done these can potentially be removed.

This basically my strategy in order to create a more distinctive interface to the OS. A programmer should by just looking at osmutex.d be able to figure out what is needed to adapt druntime for their own purpose. More of this to come, I will try to gradually implement APIs for each druntime functionality that interfaces the OS. In small steps so that the cognitive load is small.