### PR TITLE
core.sync.event2.Event2

### DIFF
--- a/druntime/src/core/sync/event.d
+++ b/druntime/src/core/sync/event.d
@@ -75,7 +75,8 @@ nothrow @nogc:
      */
     void initialize(bool manualReset, bool initialState)
     {
-        osEvent.create(manualReset, initialState);
+        osEvent = OsEvent(manualReset, initialState);
+        m_initalized = true;
     }
 
     // copying not allowed, can produce resource leaks
@@ -85,6 +86,7 @@ nothrow @nogc:
     ~this()
     {
         terminate();
+        m_initalized = false;
     }
 
     /**
@@ -104,13 +106,15 @@ nothrow @nogc:
     /// Set the event to "signaled", so that waiting clients are resumed
     void setIfInitialized()
     {
-        osEvent.setIfInitialized();
+        if(m_initalized)
+            osEvent.set();
     }
 
     /// Reset the event manually
     void reset()
     {
-        osEvent.reset();
+        if(m_initalized)
+            osEvent.reset();
     }
 
     /**
@@ -121,6 +125,9 @@ nothrow @nogc:
      */
     bool wait()
     {
+        if (!m_initalized)
+            return false;
+
         return osEvent.wait();
     }
 
@@ -135,12 +142,16 @@ nothrow @nogc:
      */
     bool wait(Duration tmout)
     {
+        if (!m_initalized)
+            return false;
+
         return osEvent.wait(tmout);
     }
 
 private:
     mixin("import " ~ osEventImport ~ ";");
     OsEvent osEvent;
+    bool m_initalized;
 }
 
 // Test single-thread (non-shared) use.

--- a/druntime/src/rt/sys/windows/osevent.d
+++ b/druntime/src/rt/sys/windows/osevent.d
@@ -12,43 +12,34 @@ import core.internal.abort : abort;
 
 struct OsEvent
 {
-    void create(bool manualReset, bool initialState) nothrow @trusted @nogc
+    this(bool manualReset, bool initialState) nothrow @trusted @nogc
     {
-        if (m_event)
-            return;
         m_event = CreateEvent(null, manualReset, initialState, null);
         m_event || abort("Error: CreateEvent failed.");
     }
 
-    void destroy() nothrow @trusted @nogc
+    ~this() nothrow @trusted @nogc
     {
-        if (m_event)
-            CloseHandle(m_event);
-        m_event = null;
+        CloseHandle(m_event);
     }
 
-    void setIfInitialized() nothrow @trusted @nogc
+    void set() nothrow @trusted @nogc
     {
-        if (m_event)
-            SetEvent(m_event);
+        SetEvent(m_event);
     }
 
     void reset() nothrow @trusted @nogc
     {
-        if (m_event)
-            ResetEvent(m_event);
+        ResetEvent(m_event);
     }
 
     bool wait() nothrow @trusted @nogc
     {
-        return m_event && WaitForSingleObject(m_event, INFINITE) == WAIT_OBJECT_0;
+        return WaitForSingleObject(m_event, INFINITE) == WAIT_OBJECT_0;
     }
 
     bool wait(Duration tmout) nothrow @trusted @nogc
     {
-        if (!m_event)
-            return false;
-
         auto maxWaitMillis = dur!("msecs")(uint.max - 1);
 
         while (tmout > maxWaitMillis)


### PR DESCRIPTION
Checking whether the `Event` object is in initialized state every time any of its methods are called is waste of CPU resources