### PR TITLE
Musl: clean

### DIFF
--- a/druntime/src/core/sys/posix/config.d
+++ b/druntime/src/core/sys/posix/config.d
@@ -84,14 +84,6 @@ else version (CRuntime_Musl)
     // off_t is always 64 bits on Musl
     enum _FILE_OFFSET_BITS   = 64;
 
-    // Not present in Musl sources
-    enum __REDIRECT          = false;
-
-    // Those three are irrelevant for Musl as it always uses 64 bits off_t
-    enum __USE_FILE_OFFSET64 = false;
-    enum __USE_LARGEFILE     = __USE_FILE_OFFSET64 && !__REDIRECT;
-    enum __USE_LARGEFILE64   = __USE_FILE_OFFSET64 && !__REDIRECT;
-
     version (D_LP64)
         enum __WORDSIZE = 64;
     else

--- a/druntime/src/core/sys/posix/dirent.d
+++ b/druntime/src/core/sys/posix/dirent.d
@@ -384,16 +384,9 @@ else version (CRuntime_Musl)
     struct DIR
     {
     }
-
-    static if ( __USE_FILE_OFFSET64 )
-    {
-        dirent* readdir64(DIR*);
-        alias   readdir64 readdir;
-    }
-    else
-    {
-        dirent* readdir(DIR*);
-    }
+    
+    dirent* readdir(DIR*);
+    alias readdir64 = readdir;
 }
 else version (CRuntime_UClibc)
 {

--- a/druntime/src/core/sys/posix/fcntl.d
+++ b/druntime/src/core/sys/posix/fcntl.d
@@ -143,17 +143,26 @@ version (linux)
   }
   else version (MIPS_Any)
   {
-    static if ( __USE_FILE_OFFSET64 )
+    version (CRuntime_Musl)
     {
-      enum F_GETLK      = 33;
-      enum F_SETLK      = 34;
-      enum F_SETLKW     = 35;
+        enum F_GETLK      = 14;
+        enum F_SETLK      = 6;
+        enum F_SETLKW     = 7;
     }
     else
     {
-      enum F_GETLK      = 14;
-      enum F_SETLK      = 6;
-      enum F_SETLKW     = 7;
+        static if ( __USE_FILE_OFFSET64 )
+        {
+            enum F_GETLK      = 33;
+            enum F_SETLK      = 34;
+            enum F_SETLKW     = 35;
+        }
+        else
+        {
+            enum F_GETLK      = 14;
+            enum F_SETLK      = 6;
+            enum F_SETLKW     = 7;
+        }
     }
   }
   else version (LoongArch64)

--- a/druntime/src/core/sys/posix/stdio.d
+++ b/druntime/src/core/sys/posix/stdio.d
@@ -182,34 +182,18 @@ else version (CRuntime_UClibc)
 }
 else version (CRuntime_Musl)
 {
-    static if ( __USE_FILE_OFFSET64 )
-    {
-        int   fgetpos64(FILE*, fpos_t *);
-        alias fgetpos64 fgetpos;
-
-        FILE* fopen64(const scope char*, const scope char*);
-        alias fopen64 fopen;
-
-        FILE* freopen64(const scope char*, const scope char*, FILE*);
-        alias freopen64 freopen;
-
-        int   fseek(FILE*, c_long, int);
-
-        int   fsetpos64(FILE*, const scope fpos_t*);
-        alias fsetpos64 fsetpos;
-
-        FILE* tmpfile64();
-        alias tmpfile64 tmpfile;
-    }
-    else
-    {
-        int   fgetpos(FILE*, fpos_t *);
-        FILE* fopen(const scope char*, const scope char*);
-        FILE* freopen(const scope char*, const scope char*, FILE*);
-        int   fseek(FILE*, c_long, int);
-        int   fsetpos(FILE*, const scope fpos_t*);
-        FILE* tmpfile();
-    }
+    int   fgetpos(FILE*, fpos_t *);
+    FILE* fopen(const scope char*, const scope char*);
+    FILE* freopen(const scope char*, const scope char*, FILE*);
+    int   fseek(FILE*, c_long, int);
+    int   fsetpos(FILE*, const scope fpos_t*);
+    FILE* tmpfile();
+    
+    alias fgetpos64 = fgetpos;
+    alias fopen64 = fopen;
+    alias freopen64 = freopen;
+    alias fsetpos64 = fsetpos;
+    alias tmpfile64 = tmpfile;
 }
 else version (Solaris)
 {
@@ -320,25 +304,11 @@ else version (CRuntime_Musl)
 {
     enum L_ctermid = 20;
 
-    static if ( __USE_FILE_OFFSET64 )
-    {
-        int   fseeko64(FILE*, off_t, int);
-        alias fseeko64 fseeko;
-    }
-    else
-    {
-        int   fseeko(FILE*, off_t, int);
-    }
+    int   fseeko(FILE*, off_t, int);
+    alias fseeko64 = fseeko;
 
-    static if ( __USE_FILE_OFFSET64 )
-    {
-        off_t ftello64(FILE*);
-        alias ftello64 ftello;
-    }
-    else
-    {
-        off_t ftello(FILE*);
-    }
+    off_t ftello(FILE*);
+    alias ftello64 = ftello;
 
     ssize_t getdelim(char**, size_t*, int, FILE*);
     ssize_t getline(char**, size_t*, FILE*);

--- a/druntime/src/core/sys/posix/stdlib.d
+++ b/druntime/src/core/sys/posix/stdlib.d
@@ -604,15 +604,8 @@ else version (CRuntime_Musl)
     void   srandom(uint);
     int    unlockpt(int);
 
-  static if ( __USE_LARGEFILE64 )
-  {
-    int    mkstemp64(char*);
-    alias  mkstemp64 mkstemp;
-  }
-  else
-  {
     int    mkstemp(char*);
-  }
+    alias  mkstemp64 = mkstemp;
 
 }
 else version (Solaris)

--- a/druntime/src/core/sys/posix/sys/mman.d
+++ b/druntime/src/core/sys/posix/sys/mman.d
@@ -293,11 +293,8 @@ else version (CRuntime_Bionic)
 }
 else version (CRuntime_Musl)
 {
-    static if (__USE_LARGEFILE64) void* mmap64(void*, size_t, int, int, int, off_t);
-    static if (__USE_FILE_OFFSET64)
-        alias mmap = mmap64;
-    else
-        void* mmap(void*, size_t, int, int, int, off_t);
+    void* mmap(void*, size_t, int, int, int, off_t);
+    alias mmap64 = mmap;
     int munmap(void*, size_t);
 }
 else version (CRuntime_UClibc)

--- a/druntime/src/core/sys/posix/sys/resource.d
+++ b/druntime/src/core/sys/posix/sys/resource.d
@@ -77,19 +77,27 @@ version (linux)
     enum
     {
         PRIO_PROCESS = 0,
-        PRIO_PGRP    = 1,
-        PRIO_USER    = 2,
+        PRIO_PGRP = 1,
+        PRIO_USER = 2,
     }
 
-    static if (__USE_FILE_OFFSET64)
-         alias ulong rlim_t;
-    else
-         alias c_ulong rlim_t;
-
-    static if (__USE_FILE_OFFSET64)
-        enum RLIM_INFINITY = 0xffffffffffffffffUL;
-    else
+    version (CRuntime_Musl)
+    {
+        alias c_ulong rlim_t;
         enum RLIM_INFINITY = cast(c_ulong)(~0UL);
+    }
+    else
+    {
+        static if (__USE_FILE_OFFSET64)
+            alias ulong rlim_t;
+        else
+            alias c_ulong rlim_t;
+
+        static if (__USE_FILE_OFFSET64)
+            enum RLIM_INFINITY = 0xffffffffffffffffUL;
+        else
+            enum RLIM_INFINITY = cast(c_ulong)(~0UL);
+    }
 
     enum RLIM_SAVED_MAX = RLIM_INFINITY;
     enum RLIM_SAVED_CUR = RLIM_INFINITY;

--- a/druntime/src/core/sys/posix/sys/stat.d
+++ b/druntime/src/core/sys/posix/sys/stat.d
@@ -103,7 +103,7 @@ version (linux)
             }
             version (CRuntime_Musl)
             {
-                uint        __st_ino;
+                ino_t       st_ino;
                 c_ulong     __unused4;
                 c_ulong     __unused5;
             }
@@ -111,11 +111,11 @@ version (linux)
             {
                 static if (__USE_FILE_OFFSET64)
                 {
-                    ino_t       st_ino;
+                    uint        __st_ino;
                 }
                 else
                 {
-                    uint        __st_ino;
+                    ino_t       st_ino;
                     c_ulong     __unused4;
                     c_ulong     __unused5;
                 }

--- a/druntime/src/core/sys/posix/sys/stat.d
+++ b/druntime/src/core/sys/posix/sys/stat.d
@@ -71,14 +71,6 @@ version (linux)
         {
             dev_t       st_dev;
             ushort      __pad1;
-            static if (!__USE_FILE_OFFSET64)
-            {
-                ino_t       st_ino;
-            }
-            else
-            {
-                uint        __st_ino;
-            }
             mode_t      st_mode;
             nlink_t     st_nlink;
             uid_t       st_uid;
@@ -109,14 +101,24 @@ version (linux)
                 time_t      st_ctime;
                 ulong_t     st_ctimensec;
             }
-            static if (__USE_FILE_OFFSET64)
+            version (CRuntime_Musl)
             {
-                ino_t       st_ino;
+                uint        __st_ino;
+                c_ulong     __unused4;
+                c_ulong     __unused5;
             }
             else
             {
-                c_ulong     __unused4;
-                c_ulong     __unused5;
+                static if (__USE_FILE_OFFSET64)
+                {
+                    ino_t       st_ino;
+                }
+                else
+                {
+                    uint        __st_ino;
+                    c_ulong     __unused4;
+                    c_ulong     __unused5;
+                }
             }
         }
     }
@@ -183,14 +185,6 @@ version (linux)
             __dev_t st_dev;
             ushort __pad1;
 
-            static if (!__USE_FILE_OFFSET64)
-            {
-                __ino_t st_ino;
-            }
-            else
-            {
-                __ino_t __st_ino;
-            }
             __mode_t st_mode;
             __nlink_t st_nlink;
             __uid_t st_uid;
@@ -198,24 +192,33 @@ version (linux)
             __dev_t st_rdev;
             ushort __pad2;
 
-            static if (!__USE_FILE_OFFSET64)
+            version (CRuntime_Musl)
             {
+                __ino_t st_ino;
                 __off_t st_size;
+                __blkcnt_t st_blocks;
+                c_ulong __unused4;
+                c_ulong __unused5;
             }
             else
             {
-                __off64_t st_size;
+                static if (!__USE_FILE_OFFSET64)
+                {
+                    __ino_t st_ino;
+                    __off_t st_size;
+                    __blkcnt_t st_blocks;
+                    c_ulong __unused4;
+                    c_ulong __unused5;
+                }
+                else
+                {
+                    __ino_t __st_ino;
+                    __off64_t st_size;
+                    __blkcnt64_t st_blocks;
+                    __ino64_t st_ino;
+                }
             }
             __blksize_t st_blksize;
-
-            static if (!__USE_FILE_OFFSET64)
-            {
-                __blkcnt_t st_blocks;
-            }
-            else
-            {
-                __blkcnt64_t st_blocks;
-            }
 
             static if ( _DEFAULT_SOURCE || _XOPEN_SOURCE >= 700)
             {
@@ -238,21 +241,18 @@ version (linux)
                 __time_t st_ctime;
                 c_ulong st_ctimensec;
             }
-
-            static if (!__USE_FILE_OFFSET64)
-            {
-                c_ulong __unused4;
-                c_ulong __unused5;
-            }
-            else
-            {
-                __ino64_t st_ino;
-            }
         }
-        static if (__USE_FILE_OFFSET64)
-            static assert(stat_t.sizeof == 104);
-        else
+        version (CRuntime_Musl)
+        {
             static assert(stat_t.sizeof == 88);
+        }
+        else
+        {
+            static if (__USE_FILE_OFFSET64)
+                static assert(stat_t.sizeof == 104);
+            else
+                static assert(stat_t.sizeof == 88);
+        }
     }
     else version (MIPS_O32)
     {
@@ -266,16 +266,29 @@ version (linux)
             uid_t       st_uid;
             gid_t       st_gid;
             c_ulong     st_rdev;
-            static if (!__USE_FILE_OFFSET64)
+            version (CRuntime_Musl)
             {
                 c_long[2]   st_pad2;
                 off_t       st_size;
                 c_long      st_pad3;
+                blkcnt_t    st_blocks;
             }
             else
             {
-                c_long[3]   st_pad2;
-                off_t       st_size;
+                static if (!__USE_FILE_OFFSET64)
+                {
+                    c_long[2]   st_pad2;
+                    off_t       st_size;
+                    c_long      st_pad3;
+                    blkcnt_t    st_blocks;
+                }
+                else
+                {
+                    c_long[3]   st_pad2;
+                    off_t       st_size;
+                    c_long      st_pad4;
+                    blkcnt_t    st_blocks;
+                }
             }
             static if (_DEFAULT_SOURCE || _XOPEN_SOURCE >= 700)
             {
@@ -299,21 +312,19 @@ version (linux)
                 c_ulong     st_ctimensec;
             }
             blksize_t   st_blksize;
-            static if (!__USE_FILE_OFFSET64)
-            {
-                blkcnt_t    st_blocks;
-            }
-            else
-            {
-                c_long      st_pad4;
-                blkcnt_t    st_blocks;
-            }
             c_long[14]  st_pad5;
         }
-        static if (!__USE_FILE_OFFSET64)
+        version (CRuntime_Musl)
+        {
             static assert(stat_t.sizeof == 144);
+        }
         else
-            static assert(stat_t.sizeof == 160);
+        {
+            static if (!__USE_FILE_OFFSET64)
+                static assert(stat_t.sizeof == 144);
+            else
+                static assert(stat_t.sizeof == 160);
+        }
     }
     else version (MIPS64)
     {
@@ -327,7 +338,7 @@ version (linux)
             uid_t       st_uid;
             gid_t       st_gid;
             dev_t       st_rdev;
-            static if (!__USE_FILE_OFFSET64)
+            version (CRuntime_Musl)
             {
                 uint[2]     st_pad2;
                 off_t       st_size;
@@ -335,8 +346,17 @@ version (linux)
             }
             else
             {
-                uint[3]     st_pad2;
-                off_t       st_size;
+                static if (!__USE_FILE_OFFSET64)
+                {
+                    uint[2]     st_pad2;
+                    off_t       st_size;
+                    int         st_pad3;
+                }
+                else
+                {
+                    uint[3]     st_pad2;
+                    off_t       st_size;
+                }
             }
             static if (_DEFAULT_SOURCE || _XOPEN_SOURCE >= 700)
             {
@@ -366,17 +386,31 @@ version (linux)
         }
         version (MIPS_N32)
         {
-            static if (!__USE_FILE_OFFSET64)
+            version (CRuntime_Musl)
+            {
                 static assert(stat_t.sizeof == 160);
+            }
             else
-                static assert(stat_t.sizeof == 176);
+            {
+                static if (!__USE_FILE_OFFSET64)
+                    static assert(stat_t.sizeof == 160);
+                else
+                    static assert(stat_t.sizeof == 176);
+            }
         }
         else version (MIPS_O64)
         {
-            static if (!__USE_FILE_OFFSET64)
+            version (CRuntime_Musl)
+            {
                 static assert(stat_t.sizeof == 160);
+            }
             else
-                static assert(stat_t.sizeof == 176);
+            {
+                static if (!__USE_FILE_OFFSET64)
+                    static assert(stat_t.sizeof == 160);
+                else
+                    static assert(stat_t.sizeof == 176);
+            }
         }
         else
         {
@@ -388,13 +422,20 @@ version (linux)
         struct stat_t
         {
             dev_t       st_dev;
-            static if (!__USE_FILE_OFFSET64)
+            version (CRuntime_Musl)
             {
-                ushort  __pad1;
                 ino_t   st_ino;
             }
             else
-                ino_t   st_ino;
+            {
+                static if (!__USE_FILE_OFFSET64)
+                {
+                    ushort  __pad1;
+                    ino_t   st_ino;
+                }
+                else
+                    ino_t   st_ino;
+            }
             mode_t      st_mode;
             nlink_t     st_nlink;
             uid_t       st_uid;
@@ -428,10 +469,17 @@ version (linux)
             c_ulong     __unused4;
             c_ulong     __unused5;
         }
-        static if (__USE_FILE_OFFSET64)
-            static assert(stat_t.sizeof == 104);
-        else
+        version (CRuntime_Musl)
+        {
             static assert(stat_t.sizeof == 88);
+        }
+        else
+        {
+            static if (__USE_FILE_OFFSET64)
+                static assert(stat_t.sizeof == 104);
+            else
+                static assert(stat_t.sizeof == 88);
+        }
     }
     else version (PPC64)
     {
@@ -498,13 +546,26 @@ version (linux)
         {
             __dev_t st_dev;
 
-            static if (__USE_FILE_OFFSET64)
+            version (CRuntime_Musl)
             {
-                __ino64_t st_ino;
+                __ino_t st_ino;
+                __off_t st_size;
+                __blkcnt_t st_blocks;
             }
             else
             {
-                __ino_t st_ino;
+                static if (__USE_FILE_OFFSET64)
+                {
+                    __ino64_t st_ino;
+                    __off64_t st_size;
+                    __blkcnt64_t st_blocks;
+                }
+                else
+                {
+                    __ino_t st_ino;
+                    __off_t st_size;
+                    __blkcnt_t st_blocks;
+                }
             }
             __mode_t st_mode;
             __nlink_t st_nlink;
@@ -513,25 +574,8 @@ version (linux)
             __dev_t st_rdev;
             __dev_t __pad1;
 
-            static if (__USE_FILE_OFFSET64)
-            {
-                __off64_t st_size;
-            }
-            else
-            {
-                __off_t st_size;
-            }
             __blksize_t st_blksize;
             int __pad2;
-
-            static if (__USE_FILE_OFFSET64)
-            {
-                __blkcnt64_t st_blocks;
-            }
-            else
-            {
-                __blkcnt_t st_blocks;
-            }
 
             static if (_DEFAULT_SOURCE)
             {
@@ -581,13 +625,31 @@ version (linux)
             __dev_t st_dev;
             ushort __pad1;
 
-            static if (!__USE_FILE_OFFSET64)
+            version (CRuntime_Musl)
             {
                 __ino_t st_ino;
+                __off_t st_size;
+                __blkcnt_t st_blocks;
+                c_ulong __unused4;
+                c_ulong __unused5;
             }
             else
             {
-                __ino_t __st_ino;
+                static if (!__USE_FILE_OFFSET64)
+                {
+                    __ino_t st_ino;
+                    __off_t st_size;
+                    __blkcnt_t st_blocks;
+                    c_ulong __unused4;
+                    c_ulong __unused5;
+                }
+                else
+                {
+                    __ino_t __st_ino;
+                    __off64_t st_size;
+                    __blkcnt64_t st_blocks;
+                    __ino64_t st_ino;
+                }
             }
             __mode_t st_mode;
             __nlink_t st_nlink;
@@ -596,24 +658,7 @@ version (linux)
             __dev_t st_rdev;
             ushort __pad2;
 
-            static if (!__USE_FILE_OFFSET64)
-            {
-                __off_t st_size;
-            }
-            else
-            {
-                __off64_t st_size;
-            }
             __blksize_t st_blksize;
-
-            static if (!__USE_FILE_OFFSET64)
-            {
-                __blkcnt_t st_blocks;
-            }
-            else
-            {
-                __blkcnt64_t st_blocks;
-            }
 
             static if ( _DEFAULT_SOURCE || _XOPEN_SOURCE >= 700)
             {
@@ -636,21 +681,18 @@ version (linux)
                 __time_t st_ctime;
                 c_ulong st_ctimensec;
             }
-
-            static if (!__USE_FILE_OFFSET64)
-            {
-                c_ulong __unused4;
-                c_ulong __unused5;
-            }
-            else
-            {
-                __ino64_t st_ino;
-            }
         }
-        static if (__USE_FILE_OFFSET64)
-            static assert(stat_t.sizeof == 104);
-        else
+        version (CRuntime_Musl)
+        {
             static assert(stat_t.sizeof == 88);
+        }
+        else
+        {
+            static if (__USE_FILE_OFFSET64)
+                static assert(stat_t.sizeof == 104);
+            else
+                static assert(stat_t.sizeof == 88);
+        }
     }
     else version (AArch64)
     {
@@ -675,13 +717,25 @@ version (linux)
         {
             __dev_t st_dev;
 
-            static if (!__USE_FILE_OFFSET64)
-            {
-                __ino_t st_ino;
-            }
-            else
+            version (CRuntime_Musl)
             {
                 __ino64_t st_ino;
+                __off64_t st_size;
+                __blkcnt64_t st_blocks;
+            } else
+            {
+                static if (!__USE_FILE_OFFSET64)
+                {
+                    __ino_t st_ino;
+                    __off_t st_size;
+                    __blkcnt_t st_blocks;
+                }
+                else
+                {
+                    __ino64_t st_ino;
+                    __off64_t st_size;
+                    __blkcnt64_t st_blocks;
+                }
             }
             __mode_t st_mode;
             __nlink_t st_nlink;
@@ -690,25 +744,8 @@ version (linux)
             __dev_t st_rdev;
             __dev_t __pad1;
 
-            static if (!__USE_FILE_OFFSET64)
-            {
-                __off_t st_size;
-            }
-            else
-            {
-                __off64_t st_size;
-            }
             __blksize_t st_blksize;
             int __pad2;
-
-            static if (!__USE_FILE_OFFSET64)
-            {
-                __blkcnt_t st_blocks;
-            }
-            else
-            {
-                __blkcnt64_t st_blocks;
-            }
 
             static if (_DEFAULT_SOURCE)
             {
@@ -776,24 +813,25 @@ version (linux)
             __dev_t st_rdev;
             ushort __pad2;
 
-            static if (!__USE_FILE_OFFSET64)
+            version (CRuntime_Musl)
             {
                 __off_t st_size;
-            }
-            else
-            {
-                __off64_t st_size;
-            }
-            __blksize_t st_blksize;
-
-            static if (!__USE_FILE_OFFSET64)
-            {
                 __blkcnt_t st_blocks;
             }
             else
             {
-                __blkcnt64_t st_blocks;
+                static if (!__USE_FILE_OFFSET64)
+                {
+                    __off_t st_size;
+                    __blkcnt_t st_blocks;
+                }
+                else
+                {
+                    __off64_t st_size;
+                    __blkcnt64_t st_blocks;
+                }
             }
+            __blksize_t st_blksize;
 
             static if (_XOPEN_SOURCE >= 700)
             {
@@ -820,14 +858,24 @@ version (linux)
             c_ulong __unused4;
             c_ulong __unused5;
         }
-        static if (__USE_LARGEFILE64) alias stat_t stat64_t;
-
-        static if (__WORDSIZE == 64)
-            static assert(stat_t.sizeof == 144);
-        else static if (__USE_FILE_OFFSET64)
-            static assert(stat_t.sizeof == 104);
+        version (CRuntime_Musl)
+        {
+            static if (__WORDSIZE == 64)
+                static assert(stat_t.sizeof == 144);
+            else
+                static assert(stat_t.sizeof == 88);
+        }
         else
-            static assert(stat_t.sizeof == 88);
+        {
+            static if (__USE_LARGEFILE64) alias stat_t stat64_t;
+
+            static if (__WORDSIZE == 64)
+                static assert(stat_t.sizeof == 144);
+            else static if (__USE_FILE_OFFSET64)
+                static assert(stat_t.sizeof == 104);
+            else
+                static assert(stat_t.sizeof == 88);
+        }
 
     }
     else version (S390)
@@ -863,15 +911,25 @@ version (linux)
             __gid_t st_gid;
             __dev_t st_rdev;
             uint __pad2;
-            static if (!__USE_FILE_OFFSET64)
+            version (CRuntime_Musl)
+            {
                 __off_t st_size;
-            else
-                __off64_t st_size;
-            __blksize_t st_blksize;
-            static if (!__USE_FILE_OFFSET64)
                 __blkcnt_t st_blocks;
+            }
             else
-                __blkcnt64_t st_blocks;
+            {
+                static if (!__USE_FILE_OFFSET64)
+                {
+                    __off_t st_size;
+                    __blkcnt_t st_blocks;
+                }
+                else
+                {
+                    __off64_t st_size;
+                    __blkcnt64_t st_blocks;
+                }
+            }
+            __blksize_t st_blksize;
             static if (_XOPEN_SOURCE >= 700)
             {
                 __timespec st_atim;
@@ -901,10 +959,17 @@ version (linux)
             else
                 __ino64_t st_ino;
         }
-        static if (__USE_FILE_OFFSET64)
-            static assert(stat_t.sizeof == 104);
-        else
+        version (CRuntime_Musl)
+        {
             static assert(stat_t.sizeof == 88);
+        }
+        else
+        {
+            static if (__USE_FILE_OFFSET64)
+                static assert(stat_t.sizeof == 104);
+            else
+                static assert(stat_t.sizeof == 88);
+        }
     }
     else version (SystemZ)
     {

--- a/druntime/src/core/sys/posix/sys/stat.d
+++ b/druntime/src/core/sys/posix/sys/stat.d
@@ -112,6 +112,7 @@ version (linux)
                 static if (__USE_FILE_OFFSET64)
                 {
                     uint        __st_ino;
+                    ino_t       st_ino;
                 }
                 else
                 {

--- a/druntime/src/core/sys/posix/sys/stat.d
+++ b/druntime/src/core/sys/posix/sys/stat.d
@@ -719,10 +719,11 @@ version (linux)
 
             version (CRuntime_Musl)
             {
-                __ino64_t st_ino;
-                __off64_t st_size;
-                __blkcnt64_t st_blocks;
-            } else
+                __ino_t st_ino;
+                __off_t st_size;
+                __blkcnt_t st_blocks;
+            }
+            else
             {
                 static if (!__USE_FILE_OFFSET64)
                 {

--- a/druntime/src/core/sys/posix/sys/statvfs.d
+++ b/druntime/src/core/sys/posix/sys/statvfs.d
@@ -71,18 +71,28 @@ version (CRuntime_Glibc) {
         }
     }
 
-    static if ( __USE_FILE_OFFSET64 )
-    {
-        int statvfs64 (const char * file, statvfs_t* buf);
-        alias statvfs64 statvfs;
-
-        int fstatvfs64 (int fildes, statvfs_t *buf) @trusted;
-        alias fstatvfs64 fstatvfs;
-    }
-    else
+    version (CRuntime_Musl)
     {
         int statvfs (const char * file, statvfs_t* buf);
         int fstatvfs (int fildes, statvfs_t *buf);
+        alias statvfs64 = statvfs;
+        alias fstatvfs64 = fstatvfs;
+    }
+    else
+    {
+        static if ( __USE_FILE_OFFSET64 )
+        {
+            int statvfs64 (const char * file, statvfs_t* buf);
+            alias statvfs64 statvfs;
+
+            int fstatvfs64 (int fildes, statvfs_t *buf) @trusted;
+            alias fstatvfs64 fstatvfs;
+        }
+        else
+        {
+            int statvfs (const char * file, statvfs_t* buf);
+            int fstatvfs (int fildes, statvfs_t *buf);
+        }
     }
 
 }

--- a/druntime/src/core/sys/posix/sys/types.d
+++ b/druntime/src/core/sys/posix/sys/types.d
@@ -87,18 +87,6 @@ uid_t
 
 version (linux)
 {
-  static if ( __USE_FILE_OFFSET64 )
-  {
-    alias long      blkcnt_t;
-    alias ulong     ino_t;
-    alias long      off_t;
-  }
-  else
-  {
-    alias slong_t   blkcnt_t;
-    alias ulong_t   ino_t;
-    alias slong_t   off_t;
-  }
     alias slong_t   blksize_t;
     alias ulong     dev_t;
     alias uint      gid_t;
@@ -106,11 +94,14 @@ version (linux)
     alias ulong_t   nlink_t;
     alias int       pid_t;
     //size_t (defined in core.stdc.stddef)
-    alias c_long    ssize_t;
-    alias uint      uid_t;
+    alias c_long ssize_t;
+    alias uint uid_t;
 
     version (CRuntime_Musl)
     {
+        alias slong_t blkcnt_t;
+        alias ulong_t ino_t;
+        alias slong_t off_t;
         /**
          * Musl versions before v1.2.0 (up to v1.1.24) had different
          * definitions for `time_t` for 32 bits.
@@ -131,15 +122,27 @@ version (linux)
          * one can recompile druntime with `CRuntime_Musl_Pre_Time64`.
          */
         version (D_X32)
-           alias long   time_t;
+            alias long time_t;
         else version (CRuntime_Musl_Pre_Time64)
             alias c_long time_t;
         else
-            alias long  time_t;
+            alias long time_t;
     }
     else
     {
-        alias slong_t   time_t;
+        static if (__USE_FILE_OFFSET64)
+        {
+            alias long blkcnt_t;
+            alias ulong ino_t;
+            alias long off_t;
+        }
+        else
+        {
+            alias slong_t blkcnt_t;
+            alias ulong_t ino_t;
+            alias slong_t off_t;
+        }
+        alias slong_t time_t;
     }
 }
 else version (Darwin)
@@ -299,15 +302,21 @@ useconds_t
 
 version (linux)
 {
-  static if ( __USE_FILE_OFFSET64 )
-  {
-    alias ulong     fsblkcnt_t;
-    alias ulong     fsfilcnt_t;
-  }
-  else
+  version(CRuntime_Musl)
   {
     alias ulong_t   fsblkcnt_t;
     alias ulong_t   fsfilcnt_t;
+  } else {
+    static if ( __USE_FILE_OFFSET64 )
+    {
+        alias ulong     fsblkcnt_t;
+        alias ulong     fsfilcnt_t;
+    }
+    else
+    {
+        alias ulong_t   fsblkcnt_t;
+        alias ulong_t   fsfilcnt_t;
+    }
   }
     alias slong_t   clock_t;
     alias uint      id_t;


### PR DESCRIPTION
Based on: #66 

```bash
$ ./opend/ldc/build/bin/ldc2 --version | head -n 5
LDC - the LLVM D compiler (1.36.0):
  based on DMD v2.106.1 and LLVM 17.0.5
  built with LDC - the LLVM D compiler (1.36.0)
  Default target: x86_64-alpine-linux-musl
  Host CPU: znver3
  ```

Thanks, [JohanEngelen](https://github.com/JohanEngelen) for help.

#### References
- https://github.com/ldc-developers/ldc/pull/4616
- https://github.com/dlang/dmd/pull/16361

cc: @adamdruppe 