### PR TITLE
Add GH action for Linux build

### DIFF
--- a/.github/workflows/build_linux_x64
+++ b/.github/workflows/build_linux_x64
@@ -1,0 +1,43 @@
+name: Build Linux x64
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install upstream dmd
+      run: curl -fsS https://dlang.org/install.sh | bash -s dmd
+
+    - name: Set upstream dmd to PATH
+      run: |
+        source ~/dlang/dmd-2.108.0/activate
+        make dmd
+        make druntime
+    
+    - name: Make dmd executable
+      run: chmod +x ./generated/linux/release/64/dmd
+
+    - name: Create tarball
+      run: tar -czf opend_linux_x64.tar.gz -C generated/linux/release/64 .
+
+    - name: Archive production artifacts
+      uses: actions/upload-artifact@v4
+      with:
+          name: opend_linux_x64.tar.gz
+          path: opend_linux_x64.tar.gz
+
+    - name: Release
+      uses: softprops/action-gh-release@v2
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: opend_linux_x64.tar.gz
+      


### PR DESCRIPTION
This is a GH Action pipeline that builds and publisher Linux x64 binaries on each commit. It pretty much follows instructions from http://opendlang.org/start.html
I wanted to open a PR for both Win64 and Linux64 but Windows is giving me hard time.
The pipeline is pretty bare bones but does the job. Comments are welcome