### PR TITLE
Unpacking: do not require storage classes if type is specified.

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -1195,9 +1195,9 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 {
                     error("`auto ref` unpacked variables are not supported");
                 }
-                if (storage_class == STC.undefined_)
+                if (!t && storage_class == STC.undefined_)
                 {
-                    error("unpacked variables need at least one storage class, did you mean `auto %s`?", i.toChars());
+                    error("unpacked variable needs at least one storage class, did you mean `auto %s`?", i.toChars());
                 }
                 vars.push(new AST.VarDeclaration(loc, t, i, null, storage_class)); // TODO: UDAs
             }


### PR DESCRIPTION
As mojo pointed out in discord:

```
@tg I am just referencing the DIP idea post:

    Types can be declared explicitly, or inferred, independently for each variable:

(int a, (string b, auto c)) = t(1, t("2", 3.0f));


but in my tests:

auto foo() => t(1, 2);
(int a, int b) = foo(); 


test_01.d(21): Error: unpacked variables need at least one storage class, did you mean `auto a`?
test_01.d(21): Error: unpacked variables need at least one storage class, did you mean `auto b`?


This works:

( auto a, auto b) = foo;
```

This fixes that issue.