### PR TITLE
Parse extern (a, b) = ...; and scope (a, b) = ...;.

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -804,7 +804,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 }
             case TOK.extern_:
                 {
-                    if (peekNext() != TOK.leftParenthesis)
+                    Token* next = peek(&token);
+                    if (next.value != TOK.leftParenthesis || peekPastParen(next).value == TOK.assign)
                     {
                         stc = STC.extern_;
                         goto Lstc;
@@ -4520,7 +4521,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
 
             case TOK.extern_:
                 {
-                    if (peekNext() != TOK.leftParenthesis)
+                    Token* next = peek(&token);
+                    if (next.value != TOK.leftParenthesis || peekPastParen(next).value == TOK.assign)
                     {
                         stc = STC.extern_;
                         goto L1;
@@ -6468,7 +6470,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             goto Lerror;
 
         case TOK.scope_:
-            if (peekNext() != TOK.leftParenthesis)
+            auto next = peek(&token);
+            if (next.value != TOK.leftParenthesis || peekPastParen(next).value == TOK.assign)
                 goto Ldeclaration; // scope used as storage class
             nextToken();
             check(TOK.leftParenthesis);


### PR DESCRIPTION
Quirin talked a bit about ambiguity issues with his primary type DIP today and we noticed that my unpacking parser has some missing cases (there is no ambiguity, but a lot of similar cases are tricky):

```d
extern (a, b) = tuple (1, 2); // parser thinks this is a linkage declaration

void main(){
    scope (a, b) = tuple(1, 2); // parser thinks this is a scope guard
}
```

This patch fixes both of those parsing issues, by detecting the `=` after the parentheses. This is not very important for `extern`, as `extern` declarations do not support initializers anyway, but parsing it correctly does improve the error message.