### PR TITLE
Unpacking parser fix

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -1083,7 +1083,9 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 continue;
 
             case TOK.leftParenthesis:
-                goto Ldeclaration;
+                if (peekPastParen(&token).value == TOK.assign) // (for better error messages)
+                    goto Ldeclaration;
+                goto default;
 
             default:
                 error("declaration expected, not `%s`", token.toChars());


### PR DESCRIPTION
Fixes some `fail_compilation` tests in upstream. (Does not influence functionality, but makes some error messages slightly better and it will be in what I PR to upstream.)