### PR TITLE
WIP: Deprecate default initialization for variables

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -1539,12 +1539,21 @@ version (IN_LLVM)
         if (dsym.storage_class & STC.extern_ && dsym._init)
             .error(dsym.loc, "%s `%s` extern symbols cannot have initializers", dsym.kind, dsym.toPrettyChars);
 
-        if(dsym._init)
+        if (dsym._init || dsym.isRef || dsym.isParameter)
         {
             return;
         }
 
-        .deprecation(dsym.loc, "uninitialized variable `%s`, please initialize to a value or:", dsym.toPrettyChars);
+        if (strcmp(dsym.type.toChars(), "float") != 0 &&
+            strcmp(dsym.type.toChars(), "double") != 0 &&
+            strcmp(dsym.type.toChars(), "real") != 0 &&
+            strcmp(dsym.type.toChars(), "char") != 0)
+        {
+            return;
+        }
+
+        .deprecation(dsym.loc, "`%s`: values of type `%s` might not initialize to what you expect, consider to either:", dsym.toPrettyChars(), dsym.type.toChars());
+        errorSupplemental(dsym.loc, "- initiazlie to a useful value");
         errorSupplemental(dsym.loc, "- use `= %s.init;` to explicitly initialize to default", dsym.type.toChars());
         errorSupplemental(dsym.loc, "- use `= void;` to explicitly avoid initialization");
     }


### PR DESCRIPTION
Please treat this PR as a suggestion rather than a concrete fix for now. I want to discuss things before I blow up all of existing code :)

Long story short, the "what the default value should be" is a long and ongoing discussion, but I figured that disallowing default values is the actual way to go. No more wondering! However, making this an error would break __way__ to much code. To be honest, even with a deprecation this ends up spitting millions of deprecation messages, so there are a few things I can suggest from the top of my head:

* Disable this deprecation for std.* and core.* modules, so we can slowly adjust the code there
* Hide this behind a compiler switch
*  **(solution that I kinda like)** Only do this for `float`, `double`, and `real` types that actually induce problems when not initialized properly, but also make it a hardcore error

Suggestions and improvements are quite welcome