### PR TITLE
Traits resolve function call

### DIFF
--- a/compiler/src/dmd/id.d
+++ b/compiler/src/dmd/id.d
@@ -520,6 +520,7 @@ immutable Msgtable[] msgtable =
     { "parameters" },
     { "docComment" },
     { "resolveFunctionCall" },
+    { "canResolveFunctionCall" },
 
     // For C++ mangling
     { "allocator" },


### PR DESCRIPTION
- new trait : `canResolveFunctionCall`
- new usage:  `__traits(resolveFunctionCall, expression)`
