### PR TITLE
Implement trait `getBuiltIn`

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -8844,6 +8844,7 @@ struct Id final
     static Identifier* outp;
     static Identifier* outpl;
     static Identifier* outpw;
+    static Identifier* getBuiltIn;
     static Identifier* isAbstractClass;
     static Identifier* isArithmetic;
     static Identifier* isAssociativeArray;

--- a/compiler/src/dmd/id.d
+++ b/compiler/src/dmd/id.d
@@ -456,6 +456,7 @@ immutable Msgtable[] msgtable =
     { "outpw"},
 
     // Traits
+    { "getBuiltIn" },
     { "isAbstractClass" },
     { "isArithmetic" },
     { "isAssociativeArray" },

--- a/compiler/src/dmd/traits.d
+++ b/compiler/src/dmd/traits.d
@@ -467,13 +467,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             return ErrorExp.get();
         }
         const builtInName = seNeedle.peekString();
-
-        switch(builtInName)
-        {
-        default:
-            error(e.loc, "`%.*s` is not a retrievable built-in", cast(int) builtInName.length, builtInName.ptr);
-            return ErrorExp.get();
-        }
+        return resolveGetBuiltIn(builtInName, e.loc);
     }
     if (e.ident == Id.isArithmetic)
     {
@@ -2625,4 +2619,34 @@ private void traitNotFound(TraitsExp e) @system
         error(e.loc, "unrecognized trait `%s`, did you mean `%.*s`?", e.ident.toChars(), cast(int) sub.length, sub.ptr);
     else
         error(e.loc, "unrecognized trait `%s`", e.ident.toChars());
+}
+
+private Expression resolveGetBuiltIn(const(char)[] name, Loc loc)
+{
+    // Signed integer types
+    if (name.iequals("int8"))
+        return new TypeExp(loc, Type.tint8);
+    if (name.iequals("int16"))
+        return new TypeExp(loc, Type.tint16);
+    if (name.iequals("int32"))
+        return new TypeExp(loc, Type.tint32);
+    if (name.iequals("int64"))
+        return new TypeExp(loc, Type.tint64);
+    if (name.iequals("int128"))
+        return new TypeExp(loc, Type.tint128);
+
+    // Unsigned integer types
+    if (name.iequals("uint8"))
+        return new TypeExp(loc, Type.tuns8);
+    if (name.iequals("uint16"))
+        return new TypeExp(loc, Type.tuns16);
+    if (name.iequals("uint32"))
+        return new TypeExp(loc, Type.tuns32);
+    if (name.iequals("uint64"))
+        return new TypeExp(loc, Type.tuns64);
+    if (name.iequals("uint128"))
+        return new TypeExp(loc, Type.tuns128);
+
+    error(loc, "`%.*s` is not a retrievable built-in", cast(int) name.length, name.ptr);
+    return ErrorExp.get();
 }

--- a/compiler/src/dmd/traits.d
+++ b/compiler/src/dmd/traits.d
@@ -440,6 +440,41 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         });
     }
 
+    if (e.ident == Id.getBuiltIn)
+    {
+        if (dim != 1)
+            return dimError(1);
+
+        auto exNeedle = isExpression((*e.args)[0]);
+        if (!exNeedle)
+        {
+            error(e.loc, "expression expected as first argument of __traits `%s`", e.ident.toChars());
+            return ErrorExp.get();
+        }
+        exNeedle = exNeedle.ctfeInterpret();
+
+        StringExp seNeedle = exNeedle.toStringExp();
+        if (!seNeedle || seNeedle.len == 0)
+        {
+            error(e.loc, "string expected as first argument of __traits `%s` instead of `%s`", e.ident.toChars(), exNeedle.toChars());
+            return ErrorExp.get();
+        }
+        seNeedle = seNeedle.toUTF8(sc);
+
+        if (seNeedle.sz != 1)
+        {
+            error(e.loc, "string must be chars");
+            return ErrorExp.get();
+        }
+        const builtInName = seNeedle.peekString();
+
+        switch(builtInName)
+        {
+        default:
+            error(e.loc, "`%.*s` is not a retrievable built-in", cast(int) builtInName.length, builtInName.ptr);
+            return ErrorExp.get();
+        }
+    }
     if (e.ident == Id.isArithmetic)
     {
         return isTypeX(t => t.isintegral() || t.isfloating());
@@ -2499,7 +2534,7 @@ private void traitNotFound(TraitsExp e) @system
         initialized = true;     // lazy initialization
 
         // All possible traits
-        __gshared Identifier*[62] idents =
+        __gshared Identifier*[63] idents =
         [
             &Id.allMembers,
             &Id.child,
@@ -2510,6 +2545,7 @@ private void traitNotFound(TraitsExp e) @system
             &Id.fullyQualifiedName,
             &Id.getAliasThis,
             &Id.getAttributes,
+            &Id.getBuiltIn,
             &Id.getFunctionAttributes,
             &Id.getFunctionVariadicStyle,
             &Id.getLinkage,


### PR DESCRIPTION
This is an alternative way to supply new built-ins to user code.
No built-ins have been added yet. Though this is subject to change after initial review/feedback.

```d
// Feature showcase
alias Int32 = __traits(getBuiltIn, "int32");
```

This differs from the upstream approach where a symbol is added to Druntime and then special cased in the compiler. Using this trait, a plain old alias can be added to Druntime instead.
(An argument for the traditional approach is that, obviously, most D code relies on the availability of the runtime anyway.)

Some users might find this new variant more elegant.

In theory this approach could be used to reduce the number of keywords and convert built-in types to aliases — similar to `string`/`wstring`/`dstring`. Not that I’d recommend doing so, though.