### PR TITLE
Use `starts_with` instead of `startswith` in `split-file.cpp`

### DIFF
--- a/ldc/utils/split-file.cpp
+++ b/ldc/utils/split-file.cpp
@@ -110,9 +110,9 @@ static int handle(MemoryBuffer &inputBuf, StringRef input) {
   for (line_iterator i(inputBuf, /*SkipBlanks=*/false, '\0'); !i.is_at_eof();) {
     const int64_t lineNo = i.line_number();
     const StringRef line = *i++;
-    const size_t markerLen = line.startswith("//") ? 6 : 5;
+    const size_t markerLen = line.starts_with("//") ? 6 : 5;
     if (!(line.size() >= markerLen &&
-          line.substr(markerLen - 4).startswith("--- ")))
+          line.substr(markerLen - 4).starts_with("--- ")))
       continue;
     separator = line.substr(0, markerLen);
     const StringRef partName = line.substr(markerLen);


### PR DESCRIPTION
`StringRef::startswith` was deprecated in LLVM 18, and removed in LLVM 19.

It's replacement is `StringRef::starts_with` (a simple rename/alias), introduced in LLVM 16.