### PR TITLE
fix foreach closures

### DIFF
--- a/changelog/dmd.foreach-closure.dd
+++ b/changelog/dmd.foreach-closure.dd
@@ -1,0 +1,1 @@
+Lambdas in `foreach` loops now capture a fresh variable for every iteration.

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -732,6 +732,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         fs.func = sc.func;
         if (fs.func.fes)
             fs.func = fs.func.fes.func;
+        const isClosure = isForeachBodyClosure(fs._body);
 
         VarDeclaration vinit = null;
         fs.aggr = fs.aggr.expressionSemantic(sc);
@@ -957,17 +958,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             if (!flde)
                 return null;
 
-            // Resolve any forward referenced goto's
-            foreach (ScopeStatement ss; *fs.gotos)
-            {
-                GotoStatement gs = ss.statement.isGotoStatement();
-                if (!gs.label.statement)
-                {
-                    // 'Promote' it to this scope, and replace with a return
-                    fs.cases.push(gs);
-                    ss.statement = new ReturnStatement(Loc.initial, new IntegerExp(fs.cases.length + 1));
-                }
-            }
+            resolveForeachGotos(fs);
 
             Expression e = null;
             if (vinit)
@@ -1248,7 +1239,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                     }
                     else
                     {
-                        auto ei = new ExpInitializer(loc, new IdentifierExp(loc, fs.key.ident));
+                        auto ei = new ExpInitializer(loc, new VarExp(loc, fs.key));
                         auto v = new VarDeclaration(loc, p.type, p.ident, ei);
                         v.storage_class |= STC.foreach_ | (p.storageClass & STC.ref_);
                         fs._body = new CompoundStatement(loc, new ExpStatement(loc, v), fs._body);
@@ -1261,6 +1252,17 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                     }
                 }
                 fs._body = new CompoundStatement(loc, ds, fs._body);
+
+                if (isClosure)
+                {
+                    // declare the foreach variables inside the callback
+                    tmp.dsymbolSemantic(sc2);
+                    fs.key.dsymbolSemantic(sc2);
+                    fs.parameters = new Parameters();
+                    fs._body = callForeachBody(sc2, fs);
+                    if (!fs._body)
+                        return retError();
+                }
 
                 Statement s = new ForStatement(loc, forinit, cond, increment, fs._body, fs.endloc);
                 if (auto ls = checkLabeledLoop(sc, fs))   // https://issues.dlang.org/show_bug.cgi?id=15450
@@ -1401,6 +1403,15 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 {
                     auto vd = copyToTemp(STC.ref_, "__front", einit);
                     vd.dsymbolSemantic(sc);
+                    if (isClosure)
+                    {
+                        // the first temporary is used to infer the tuple type
+                        // before the callback is constructed
+
+                        // since the callback is in a different scope, we need
+                        // to construct a new variable to insert into the callback
+                        vd = copyToTemp(STC.ref_, "__front", einit);
+                    }
                     makeargs = new ExpStatement(loc, vd);
 
                     // Resolve inout qualifier of front type
@@ -1450,13 +1461,26 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                         }
 
                         auto var = new VarDeclaration(loc, p.type, p.ident, new ExpInitializer(loc, exp));
-                        var.storage_class |= STC.ctfe | STC.ref_ | STC.foreach_;
+                        var.storage_class |= STC.ctfe | STC.foreach_;
+                        if (!isClosure || (p.storageClass & STC.ref_) || !p.type.baseElemOf().isCopyable())
+                            var.storage_class |= STC.ref_;
                         makeargs = new CompoundStatement(loc, makeargs, new ExpStatement(loc, var));
                     }
                 }
 
                 fs._body = unpackVariables(fs._body);
-                forbody = new CompoundStatement(loc, makeargs, fs._body);
+                if (isClosure)
+                {
+                    fs._body = new CompoundStatement(loc, makeargs, fs._body);
+                    fs.parameters = new Parameters();
+                    forbody = callForeachBody(sc2, fs);
+                    if (!forbody)
+                        return retError();
+                }
+                else
+                {
+                    forbody = new CompoundStatement(loc, makeargs, fs._body);
+                }
 
                 Statement s = new ForStatement(loc, _init, condition, increment, forbody, fs.endloc);
                 if (auto ls = checkLabeledLoop(sc, fs))
@@ -1487,6 +1511,8 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
     {
         /* https://dlang.org/spec/statement.html#foreach-range-statement
          */
+
+        const isClosure = isForeachBodyClosure(fs._body);
 
         //printf("ForeachRangeStatement::semantic() %p\n", fs);
 
@@ -1671,6 +1697,23 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 v.range = new IntRange(fs.key.range.imin, fs.key.range.imax - SignExtendedNumber(1));
             }
         }
+
+        if (isClosure)
+        {
+            fs.key.dsymbolSemantic(sc);
+            tmp.dsymbolSemantic(sc);
+            auto parameters = new Parameters();
+            auto foreachBody = new ForeachStatement(loc, fs.op, parameters, null,
+                fs._body, fs.endloc);
+            foreachBody.func = sc.func;
+            if (foreachBody.func.fes)
+                foreachBody.func = foreachBody.func.fes.func;
+
+            fs._body = callForeachBody(sc, foreachBody);
+            if (!fs._body)
+                return setError();
+        }
+
         if (fs.prm.storageClass & STC.ref_)
         {
             if (fs.key.type.constConv(fs.prm.type) == MATCH.nomatch)
@@ -2630,6 +2673,12 @@ version (IN_LLVM)
         gds.sw = sc.sw;
         if (!gds.sw)
         {
+            if (sc.fes && !sc.fes.parameters.length)
+            {
+                sc.fes.cases.push(gds);
+                result = new ReturnStatement(Loc.initial, new IntegerExp(sc.fes.cases.length + 1));
+                return;
+            }
             error(gds.loc, "`goto default` not in `switch` statement");
             return setError();
         }
@@ -2654,6 +2703,18 @@ version (IN_LLVM)
 
         if (!sc.sw)
         {
+            if (sc.fes && !sc.fes.parameters.length)
+            {
+                if (gcs.exp)
+                {
+                    gcs.exp = gcs.exp.expressionSemantic(sc);
+                    if (gcs.exp.op == EXP.error)
+                        return setError();
+                }
+                sc.fes.cases.push(gcs);
+                result = new ReturnStatement(Loc.initial, new IntegerExp(sc.fes.cases.length + 1));
+                return;
+            }
             error(gcs.loc, "`goto case` not in `switch` statement");
             return setError();
         }
@@ -4252,6 +4313,67 @@ private extern(D) Statement loopReturn(Expression e, Statements* cases, const re
 
     s = new CompoundStatement(loc, a);
     return new SwitchStatement(loc, null, e, s, false, loc);
+}
+
+private bool isForeachBodyClosure(Statement body)
+{
+    extern(C++) final class ClosureVisitor : SemanticTimeTransitiveVisitor
+    {
+        alias visit = SemanticTimeTransitiveVisitor.visit;
+        bool found = false;
+        override void visit(FuncExp) { found = true; }
+        override void visit(FuncDeclaration) { found = true; }
+        override void visit(MixinExp) { found = true; }
+        override void visit(MixinStatement) { found = true; }
+        override void visit(TemplateMixin) { found = true; }
+    }
+    scope finder = new ClosureVisitor();
+    body.accept(finder);
+    return finder.found;
+}
+
+private void resolveForeachGotos(ForeachStatement fs)
+{
+    // Resolve any forward referenced goto's
+    foreach (ScopeStatement ss; *fs.gotos)
+    {
+        GotoStatement gs = ss.statement.isGotoStatement();
+        if (!gs.label.statement)
+        {
+            // 'Promote' it to this scope, and replace with a return
+            fs.cases.push(gs);
+            ss.statement = new ReturnStatement(Loc.initial, new IntegerExp(fs.cases.length + 1));
+        }
+    }
+}
+
+private Statement callForeachBody(Scope* sc, ForeachStatement fs)
+{
+    FuncExp flde = foreachBodyToFunction(sc, fs, null, false);
+    if (!flde)
+        return null;
+
+    resolveForeachGotos(fs);
+
+    const loc = fs.loc;
+    auto call = new CallExp(loc, flde);
+    auto result = new VarDeclaration(loc, Type.tint32, Identifier.generateId("__foreachResult"),
+        new ExpInitializer(loc, call));
+    result.storage_class |= STC.temp;
+
+    auto statements = new Statements();
+    statements.push(new ExpStatement(loc, result));
+
+    Expression isBreak = new EqualExp(EXP.equal, loc, new VarExp(loc, result), IntegerExp.literal!1);
+    statements.push(new IfStatement(loc, null, isBreak, new BreakStatement(loc, null), null, loc));
+
+    foreach (i, statement; *fs.cases)
+    {
+        Expression condition = new EqualExp(EXP.equal, loc, new VarExp(loc, result), new IntegerExp(i + 2));
+        statements.push(new IfStatement(loc, null, condition, statement, null, loc));
+    }
+
+    return new CompoundStatement(loc, statements);
 }
 
 /*************************************

--- a/compiler/test/runnable/foreachclosure.d
+++ b/compiler/test/runnable/foreachclosure.d
@@ -1,0 +1,321 @@
+// REQUIRED_ARGS: -preview=dip1000
+
+import std.algorithm.iteration : splitter;
+import std.conv : to;
+import std.path : chainPath;
+import std.typecons : Tuple, tuple;
+
+alias Getter = int delegate();
+
+void check(Getter[] getters, int[] expected)
+{
+    assert(getters.length == expected.length);
+    foreach (i, getter; getters)
+        assert(getter() == expected[i]);
+}
+
+struct Range
+{
+    int value;
+    @property bool empty() const { return value == 4; }
+    @property int front() const { return value; }
+    void popFront() { ++value; }
+}
+
+struct Apply
+{
+    int opApply(scope int delegate(int) dg)
+    {
+        foreach (i; 0 .. 4)
+            if (auto result = dg(i))
+                return result;
+        return 0;
+    }
+}
+
+struct PairRange
+{
+    int value;
+    @property bool empty() const { return value == 3; }
+    @property Tuple!(int, int) front() { return tuple(value, value + 10); }
+    void popFront() { ++value; }
+}
+
+struct Noncopyable
+{
+    @disable this(this);
+}
+
+struct AliasTuple(T...)
+{
+    T fields;
+    alias fields this;
+}
+
+class NoncopyablePairRange
+{
+    AliasTuple!(int, Noncopyable[2]) pair;
+    int value;
+
+    @property bool empty() const { return value == 2; }
+    @property ref typeof(pair) front() return
+    {
+        pair.fields[0] = value;
+        return pair;
+    }
+    void popFront() { ++value; }
+}
+
+mixin template CaptureLoopVariable()
+{
+    auto getter = () => i;
+}
+
+int ctfeSwitchGoto()
+{
+    switch (0)
+    {
+    case 0:
+        foreach (i; 0 .. 2)
+        {
+            auto getter = () => i;
+            if (getter() == 1)
+                goto default;
+        }
+        assert(0);
+    default:
+        return 1;
+    }
+}
+
+static assert(ctfeSwitchGoto() == 1);
+
+void testSwitchGotos()
+{
+    int reached;
+    switch (0)
+    {
+    case 0:
+        foreach (i; 0 .. 2)
+        {
+            auto getter = () => i;
+            if (getter() == 1)
+                goto default;
+        }
+        assert(0);
+    default:
+        reached = 1;
+        break;
+    }
+    assert(reached == 1);
+
+    switch (0)
+    {
+    case 0:
+        foreach (i; 0 .. 2)
+        {
+            enum target = 2;
+            auto getter = () => i;
+            if (getter() == 1)
+                goto case target;
+        }
+        assert(0);
+    case 1:
+        assert(0);
+    case 2:
+        reached = 2;
+        break;
+    default:
+        assert(0);
+    }
+    assert(reached == 2);
+
+    switch (0)
+    {
+    case 0:
+        foreach (i; 0 .. 2)
+        {
+            auto getter = () => i;
+            if (getter() == 1)
+                goto case;
+        }
+        assert(0);
+    case 1:
+        reached = 3;
+        break;
+    default:
+        assert(0);
+    }
+    assert(reached == 3);
+
+    switch (0)
+    {
+    case 0:
+        foreach (i; 0 .. 2)
+        {
+            auto outerGetter = () => i;
+            foreach (j; 0 .. 2)
+            {
+                auto innerGetter = () => j;
+                if (outerGetter() == 1 && innerGetter() == 1)
+                    goto default;
+            }
+        }
+        assert(0);
+    default:
+        reached = 4;
+        break;
+    }
+    assert(reached == 4);
+}
+
+int returnFromBody(ref Getter[] getters)
+{
+    foreach (i; 0 .. 4)
+    {
+        getters ~= () => i;
+        if (i == 2)
+            return i;
+    }
+    return -1;
+}
+
+int immediateClosures() @safe pure nothrow @nogc
+{
+    int result;
+    foreach (i; 0 .. 4)
+        result += (() @safe pure nothrow @nogc => i)();
+    return result;
+}
+
+static assert(immediateClosures() == 6);
+
+string lifetimeSensitive(scope string path) @safe
+{
+    string result;
+    foreach (part; splitter(path, ":"))
+    {
+        auto length = () @safe => part.length;
+        result = chainPath(part, "child").to!string;
+        assert(length() == part.length);
+    }
+    return result;
+}
+
+void main()
+{
+    assert(lifetimeSensitive("first:second").length);
+
+    Getter[] getters;
+    foreach (i; 0 .. 4)
+        getters ~= () => i;
+    check(getters, [0, 1, 2, 3]);
+
+    getters = null;
+    foreach_reverse (i; 0 .. 4)
+        getters ~= () => i;
+    check(getters, [3, 2, 1, 0]);
+
+    getters = null;
+    int[] values = [10, 20, 30, 40];
+    foreach (i, value; values)
+        getters ~= () => cast(int) i * 100 + value;
+    check(getters, [10, 120, 230, 340]);
+
+    getters = null;
+    foreach (value; Range())
+        getters ~= () => value;
+    check(getters, [0, 1, 2, 3]);
+
+    getters = null;
+    foreach (left, right; PairRange())
+        getters ~= () => left * 100 + right;
+    check(getters, [10, 111, 212]);
+
+    getters = null;
+    foreach (number, item; new NoncopyablePairRange())
+        getters ~= () => number;
+    check(getters, [0, 1]);
+
+    getters = null;
+    foreach (i; 0 .. 4)
+        getters ~= mixin("() => i");
+    check(getters, [0, 1, 2, 3]);
+
+    getters = null;
+    foreach (i; 0 .. 4)
+    {
+        mixin CaptureLoopVariable;
+        getters ~= getter;
+    }
+    check(getters, [0, 1, 2, 3]);
+
+    getters = null;
+    foreach (value; Apply())
+        getters ~= () => value;
+    check(getters, [0, 1, 2, 3]);
+
+    getters = null;
+    for (int i; i < 4; ++i)
+        getters ~= () => i;
+    check(getters, [4, 4, 4, 4]);
+
+    testSwitchGotos();
+
+    getters = null;
+    int outer;
+    foreach (i; 0 .. 4)
+    {
+        int local = i * 2;
+        getters ~= () => outer + i + local;
+    }
+    outer = 100;
+    check(getters, [100, 103, 106, 109]);
+
+    getters = null;
+    foreach (i; 0 .. 6)
+    {
+        if (i == 1)
+            continue;
+        getters ~= () => i;
+        if (i == 3)
+            break;
+    }
+    check(getters, [0, 2, 3]);
+
+    getters = null;
+    assert(returnFromBody(getters) == 2);
+    check(getters, [0, 1, 2]);
+
+    getters = null;
+    foreach (i; 0 .. 4)
+    {
+        getters ~= () => i;
+        if (i == 2)
+            goto done;
+    }
+    assert(0);
+done:
+    check(getters, [0, 1, 2]);
+
+    getters = null;
+outer:
+    foreach (i; 0 .. 4)
+    {
+        getters ~= () => i * 10;
+        foreach (j; 0 .. 4)
+        {
+            getters ~= () => i * 10 + j;
+            if (i == 1 && j == 1)
+                break outer;
+        }
+    }
+    check(getters, [0, 0, 1, 2, 3, 10, 10, 11]);
+
+    int[] referenced = [1, 2, 3, 4];
+    getters = null;
+    foreach (ref value; referenced)
+        getters ~= () => value;
+    referenced[] += 10;
+    check(getters, [11, 12, 13, 14]);
+}

--- a/ldc/tests/dmd/runnable/foreachclosure.d
+++ b/ldc/tests/dmd/runnable/foreachclosure.d
@@ -1,0 +1,321 @@
+// REQUIRED_ARGS: -preview=dip1000
+
+import std.algorithm.iteration : splitter;
+import std.conv : to;
+import std.path : chainPath;
+import std.typecons : Tuple, tuple;
+
+alias Getter = int delegate();
+
+void check(Getter[] getters, int[] expected)
+{
+    assert(getters.length == expected.length);
+    foreach (i, getter; getters)
+        assert(getter() == expected[i]);
+}
+
+struct Range
+{
+    int value;
+    @property bool empty() const { return value == 4; }
+    @property int front() const { return value; }
+    void popFront() { ++value; }
+}
+
+struct Apply
+{
+    int opApply(scope int delegate(int) dg)
+    {
+        foreach (i; 0 .. 4)
+            if (auto result = dg(i))
+                return result;
+        return 0;
+    }
+}
+
+struct PairRange
+{
+    int value;
+    @property bool empty() const { return value == 3; }
+    @property Tuple!(int, int) front() { return tuple(value, value + 10); }
+    void popFront() { ++value; }
+}
+
+struct Noncopyable
+{
+    @disable this(this);
+}
+
+struct AliasTuple(T...)
+{
+    T fields;
+    alias fields this;
+}
+
+class NoncopyablePairRange
+{
+    AliasTuple!(int, Noncopyable[2]) pair;
+    int value;
+
+    @property bool empty() const { return value == 2; }
+    @property ref typeof(pair) front() return
+    {
+        pair.fields[0] = value;
+        return pair;
+    }
+    void popFront() { ++value; }
+}
+
+mixin template CaptureLoopVariable()
+{
+    auto getter = () => i;
+}
+
+int ctfeSwitchGoto()
+{
+    switch (0)
+    {
+    case 0:
+        foreach (i; 0 .. 2)
+        {
+            auto getter = () => i;
+            if (getter() == 1)
+                goto default;
+        }
+        assert(0);
+    default:
+        return 1;
+    }
+}
+
+static assert(ctfeSwitchGoto() == 1);
+
+void testSwitchGotos()
+{
+    int reached;
+    switch (0)
+    {
+    case 0:
+        foreach (i; 0 .. 2)
+        {
+            auto getter = () => i;
+            if (getter() == 1)
+                goto default;
+        }
+        assert(0);
+    default:
+        reached = 1;
+        break;
+    }
+    assert(reached == 1);
+
+    switch (0)
+    {
+    case 0:
+        foreach (i; 0 .. 2)
+        {
+            enum target = 2;
+            auto getter = () => i;
+            if (getter() == 1)
+                goto case target;
+        }
+        assert(0);
+    case 1:
+        assert(0);
+    case 2:
+        reached = 2;
+        break;
+    default:
+        assert(0);
+    }
+    assert(reached == 2);
+
+    switch (0)
+    {
+    case 0:
+        foreach (i; 0 .. 2)
+        {
+            auto getter = () => i;
+            if (getter() == 1)
+                goto case;
+        }
+        assert(0);
+    case 1:
+        reached = 3;
+        break;
+    default:
+        assert(0);
+    }
+    assert(reached == 3);
+
+    switch (0)
+    {
+    case 0:
+        foreach (i; 0 .. 2)
+        {
+            auto outerGetter = () => i;
+            foreach (j; 0 .. 2)
+            {
+                auto innerGetter = () => j;
+                if (outerGetter() == 1 && innerGetter() == 1)
+                    goto default;
+            }
+        }
+        assert(0);
+    default:
+        reached = 4;
+        break;
+    }
+    assert(reached == 4);
+}
+
+int returnFromBody(ref Getter[] getters)
+{
+    foreach (i; 0 .. 4)
+    {
+        getters ~= () => i;
+        if (i == 2)
+            return i;
+    }
+    return -1;
+}
+
+int immediateClosures() @safe pure nothrow @nogc
+{
+    int result;
+    foreach (i; 0 .. 4)
+        result += (() @safe pure nothrow @nogc => i)();
+    return result;
+}
+
+static assert(immediateClosures() == 6);
+
+string lifetimeSensitive(scope string path) @safe
+{
+    string result;
+    foreach (part; splitter(path, ":"))
+    {
+        auto length = () @safe => part.length;
+        result = chainPath(part, "child").to!string;
+        assert(length() == part.length);
+    }
+    return result;
+}
+
+void main()
+{
+    assert(lifetimeSensitive("first:second").length);
+
+    Getter[] getters;
+    foreach (i; 0 .. 4)
+        getters ~= () => i;
+    check(getters, [0, 1, 2, 3]);
+
+    getters = null;
+    foreach_reverse (i; 0 .. 4)
+        getters ~= () => i;
+    check(getters, [3, 2, 1, 0]);
+
+    getters = null;
+    int[] values = [10, 20, 30, 40];
+    foreach (i, value; values)
+        getters ~= () => cast(int) i * 100 + value;
+    check(getters, [10, 120, 230, 340]);
+
+    getters = null;
+    foreach (value; Range())
+        getters ~= () => value;
+    check(getters, [0, 1, 2, 3]);
+
+    getters = null;
+    foreach (left, right; PairRange())
+        getters ~= () => left * 100 + right;
+    check(getters, [10, 111, 212]);
+
+    getters = null;
+    foreach (number, item; new NoncopyablePairRange())
+        getters ~= () => number;
+    check(getters, [0, 1]);
+
+    getters = null;
+    foreach (i; 0 .. 4)
+        getters ~= mixin("() => i");
+    check(getters, [0, 1, 2, 3]);
+
+    getters = null;
+    foreach (i; 0 .. 4)
+    {
+        mixin CaptureLoopVariable;
+        getters ~= getter;
+    }
+    check(getters, [0, 1, 2, 3]);
+
+    getters = null;
+    foreach (value; Apply())
+        getters ~= () => value;
+    check(getters, [0, 1, 2, 3]);
+
+    getters = null;
+    for (int i; i < 4; ++i)
+        getters ~= () => i;
+    check(getters, [4, 4, 4, 4]);
+
+    testSwitchGotos();
+
+    getters = null;
+    int outer;
+    foreach (i; 0 .. 4)
+    {
+        int local = i * 2;
+        getters ~= () => outer + i + local;
+    }
+    outer = 100;
+    check(getters, [100, 103, 106, 109]);
+
+    getters = null;
+    foreach (i; 0 .. 6)
+    {
+        if (i == 1)
+            continue;
+        getters ~= () => i;
+        if (i == 3)
+            break;
+    }
+    check(getters, [0, 2, 3]);
+
+    getters = null;
+    assert(returnFromBody(getters) == 2);
+    check(getters, [0, 1, 2]);
+
+    getters = null;
+    foreach (i; 0 .. 4)
+    {
+        getters ~= () => i;
+        if (i == 2)
+            goto done;
+    }
+    assert(0);
+done:
+    check(getters, [0, 1, 2]);
+
+    getters = null;
+outer:
+    foreach (i; 0 .. 4)
+    {
+        getters ~= () => i * 10;
+        foreach (j; 0 .. 4)
+        {
+            getters ~= () => i * 10 + j;
+            if (i == 1 && j == 1)
+                break outer;
+        }
+    }
+    check(getters, [0, 0, 1, 2, 3, 10, 10, 11]);
+
+    int[] referenced = [1, 2, 3, 4];
+    getters = null;
+    foreach (ref value; referenced)
+        getters ~= () => value;
+    referenced[] += 10;
+    check(getters, [11, 12, 13, 14]);
+}


### PR DESCRIPTION
# Summary

This PR fixes the age-old bug:

```d
int delegate()[] arr;
foreach (i; 0 .. 10) {
  arr ~= { return i; };
}
writeln(arr[3]()); // prints 9????
```

Modeled heavily after the opApply-based foreach loop implementation (which has never had this closure bug!)

Code is AI-generated but it seems super reasonable to me and works on my codebase